### PR TITLE
Track F[_] in Http.Message subclasses

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,4 @@
 root = true
 
 [*]
-indent_style = tab
-indent_size = 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.1]
+        scala: [3.1.3]
         java: [temurin@17]
         project: [rootJS, rootJVM]
         jsenv: [NodeJS, Chrome, Firefox]
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.1]
+        scala: [3.1.3]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,12 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ['**', '!update/**', '!pr/**']
   push:
-    branches: ['**']
+    branches: ['**', '!update/**', '!pr/**']
     tags: [v*]
 
 env:
-  PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-  SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
-  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  PGP_SECRET: ${{ secrets.PGP_SECRET }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -42,19 +37,28 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@17)
+      - name: Download Java (temurin@17)
+        id: download-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 17
 
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: jdkfile
+          java-version: 17
+          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
+
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt
@@ -92,3 +96,49 @@ jobs:
       - name: Generate API documentation
         if: matrix.java == 'temurin@17'
         run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' doc'
+
+  dependency-submission:
+    name: Submit Dependencies
+    if: github.event_name != 'pull_request'
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [3.1.1]
+        java: [temurin@17]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download Java (temurin@17)
+        id: download-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: typelevel/download-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: jdkfile
+          java-version: 17
+          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
+
+      - name: Cache sbt
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Submit Dependencies
+        uses: scalacenter/sbt-dependency-submission@v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## HttpSig library
 
 This library consists of Scala and Scala-JS components implementing the
-IETF's HTTP-Bis [Signing HTTP Messages](https://httpwg.org/http-extensions/draft-ietf-httpbis-message-signatures.html)
-spec. That spec builds on the experience of [Amazon Web Services, Signing HTTP](https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html).
+IETF's HTTP-Bis [Signing HTTP Messages](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures)
+spec (version 13). That spec builds on the experience of [Amazon Web Services, Signing HTTP](https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html).
 spec. It can be used in many ways, including authentication protocols such as
 [HttpSig](https://github.com/solid/authentication-panel/blob/main/proposals/HttpSignature.md).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ This repository contains the following projects:
   of [Signing HTTP Messages](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html)
 * [http4s](https://http4s.org) implementation of "Signing HTTP Messages" project for Java or JS clients (todo nodejs)
 
+### JavaScript Testing
+
+httpSig compiles to Java and JavaScript. 
+Testing in JS environments is done using [Selenium](https://www.selenium.dev). 
+This requires having a selenium driver. 
+On MacOs this is installed ([see Stack Overflow](https://stackoverflow.com/questions/18868743/how-to-install-selenium-webdriver-on-mac-os)) using `brew install selenium-server`. But one still requires Chrome and Firefox drivers to be installed after that.
+ * For Mozilla drivers see [their geckodriver page](https://github.com/mozilla/geckodriver/releases)
+ * For Chrome see the [Chrome Driver page](https://chromedriver.chromium.org/downloads) 
+
+Inside of sbt one can then run tests for Firefox only with
+```scala
+> set Global / useJSEnv := JSEnv.Firefox
+> test
+```
+Inside of sbt one can then run tests for Chrome only with
+```scala
+> set Global / useJSEnv := JSEnv.Chrome
+> test
+```
+NodeJS is the default.
+
+(Please fill in details for other environments)
+
 ### Released Artifacts
 
 Artifacts are released in the Sonatype [net.bblfish.crypto](https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/crypto/) 

--- a/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
@@ -17,40 +17,51 @@
 package run.cosy.akka.http
 
 import akka.http.scaladsl.model
+import akka.http.scaladsl.model.{HttpHeader, HttpMessage}
 import akka.http.scaladsl.model.headers.RawHeader
 import run.cosy.http.{Http, HttpOps}
+import akka.http.scaladsl.model as ak
 
 object AkkaTp extends Http:
-   override type Message  = model.HttpMessage
-   override type Request  = model.HttpRequest
-   override type Response = model.HttpResponse
+   override type Message[F[_]]  = model.HttpMessage
+   override type Request[F[_]]  = model.HttpRequest
+   override type Response[F[_]] = model.HttpResponse
    override type Header   = model.HttpHeader
 
-   given httpOps: HttpOps[AkkaTp.type] with
-      type A = AkkaTp.type
+   given httpOps: HttpOps[H4] with
 
-      extension (msg: Http.Message[A])
-        def headers: Seq[Http.Header[A]] = msg.headers
+      extension [F[_]](msg: Http.Message[F,H4])
+        def headers: Seq[Http.Header[H4]] =
+          val m = msg.asInstanceOf[ak.HttpMessage]
+          m.headers
 
-      extension [R <: Http.Message[A]](msg: R)
-         def addHeaders(headers: Seq[Http.Header[A]]): R =
-           // don't know how to get rid of the asInstanceOf
-           msg.withHeaders(msg.headers ++ headers).asInstanceOf[R]
+      extension [F[_], R <: Http.Message[F, H4]](msg: R)
+         def addHeaders(headers: Seq[Http.Header[H4]]): R =
+           // don't know how to get rid of the  asInstanceOf
+           val m = msg.asInstanceOf[HttpMessage]
+           val newreq = m.withHeaders(headers.map(_.asInstanceOf[HttpHeader])++m.headers)
+           newreq.asInstanceOf[R]
 
          def addHeader(name: String, value: String): R =
-           msg.withHeaders(msg.headers.prepended(RawHeader(name, value))).asInstanceOf[R]
+           val m = msg.asInstanceOf[HttpMessage]
+           m.withHeaders(m.headers.prepended(RawHeader(name, value))).asInstanceOf[R]
 
-         def removeHeader(name: String): R = msg.removeHeader(name).asInstanceOf[R]
+         def removeHeader(name: String): R =
+           val m = msg.asInstanceOf[ak.HttpMessage]
+           m.removeHeader(name).asInstanceOf[R]
 
          def headerValue(name: String): Option[String] =
+           val m = msg.asInstanceOf[HttpMessage]
            name.toLowerCase(java.util.Locale.ENGLISH) match
               case "content-type" =>
-                if msg.entity.isKnownEmpty then None
-                else Option(msg.entity.contentType.toString)
+                if m.entity.isKnownEmpty then None
+                else Option(m.entity.contentType.toString)
               case "content-length" =>
-                if msg.entity.isKnownEmpty then Some("0")
-                else msg.entity.contentLengthOption.map(_.toString)
+                if m.entity.isKnownEmpty then Some("0")
+                else m.entity.contentLengthOption.map(_.toString)
               // todo: need to adapt for multiple headers
               case _ =>
                 import scala.jdk.OptionConverters.*
-                msg.getHeader(name).toScala.nn.map(_.value.nn)
+                m.getHeader(name).toScala.nn.map(_.value.nn)
+
+end AkkaTp

--- a/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
@@ -29,20 +29,20 @@ object AkkaTp extends Http:
    override type Response[F[_]] = model.HttpResponse
    override type Header         = model.HttpHeader
 
-   given Conversion[model.HttpRequest, Http.Request[IO,H4]] with
-     def apply(req: HttpRequest): Http.Request[IO,H4] = req.asInstanceOf[Http.Request[IO,H4]]
-   given Conversion[model.HttpResponse, Http.Response[IO,H4]] with
-     def apply(req: HttpResponse): Http.Response[IO,H4] = req.asInstanceOf[Http.Response[IO,H4]]
+   given Conversion[model.HttpRequest, Http.Request[IO,HT]] with
+     def apply(req: HttpRequest): Http.Request[IO,HT] = req.asInstanceOf[Http.Request[IO,HT]]
+   given Conversion[model.HttpResponse, Http.Response[IO,HT]] with
+     def apply(req: HttpResponse): Http.Response[IO,HT] = req.asInstanceOf[Http.Response[IO,HT]]
 
-   given httpOps: HttpOps[H4] with
+   given hOps: HttpOps[HT] with
 
-      extension [F[_]](msg: Http.Message[F, H4])
-        def headers: Seq[Http.Header[H4]] =
+      extension [F[_]](msg: Http.Message[F, HT])
+        def headers: Seq[Http.Header[HT]] =
            val m = msg.asInstanceOf[ak.HttpMessage]
            m.headers
 
-      extension [F[_], R <: Http.Message[F, H4]](msg: R)
-         def addHeaders(headers: Seq[Http.Header[H4]]): R =
+      extension [F[_], R <: Http.Message[F, HT]](msg: R)
+         def addHeaders(headers: Seq[Http.Header[HT]]): R =
             // don't know how to get rid of the  asInstanceOf
             val m      = msg.asInstanceOf[HttpMessage]
             val newreq = m.withHeaders(headers.map(_.asInstanceOf[HttpHeader]) ++ m.headers)

--- a/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
@@ -26,42 +26,42 @@ object AkkaTp extends Http:
    override type Message[F[_]]  = model.HttpMessage
    override type Request[F[_]]  = model.HttpRequest
    override type Response[F[_]] = model.HttpResponse
-   override type Header   = model.HttpHeader
+   override type Header         = model.HttpHeader
 
    given httpOps: HttpOps[H4] with
 
-      extension [F[_]](msg: Http.Message[F,H4])
+      extension [F[_]](msg: Http.Message[F, H4])
         def headers: Seq[Http.Header[H4]] =
-          val m = msg.asInstanceOf[ak.HttpMessage]
-          m.headers
+           val m = msg.asInstanceOf[ak.HttpMessage]
+           m.headers
 
       extension [F[_], R <: Http.Message[F, H4]](msg: R)
          def addHeaders(headers: Seq[Http.Header[H4]]): R =
-           // don't know how to get rid of the  asInstanceOf
-           val m = msg.asInstanceOf[HttpMessage]
-           val newreq = m.withHeaders(headers.map(_.asInstanceOf[HttpHeader])++m.headers)
-           newreq.asInstanceOf[R]
+            // don't know how to get rid of the  asInstanceOf
+            val m      = msg.asInstanceOf[HttpMessage]
+            val newreq = m.withHeaders(headers.map(_.asInstanceOf[HttpHeader]) ++ m.headers)
+            newreq.asInstanceOf[R]
 
          def addHeader(name: String, value: String): R =
-           val m = msg.asInstanceOf[HttpMessage]
-           m.withHeaders(m.headers.prepended(RawHeader(name, value))).asInstanceOf[R]
+            val m = msg.asInstanceOf[HttpMessage]
+            m.withHeaders(m.headers.prepended(RawHeader(name, value))).asInstanceOf[R]
 
          def removeHeader(name: String): R =
-           val m = msg.asInstanceOf[ak.HttpMessage]
-           m.removeHeader(name).asInstanceOf[R]
+            val m = msg.asInstanceOf[ak.HttpMessage]
+            m.removeHeader(name).asInstanceOf[R]
 
          def headerValue(name: String): Option[String] =
-           val m = msg.asInstanceOf[HttpMessage]
-           name.toLowerCase(java.util.Locale.ENGLISH) match
-              case "content-type" =>
-                if m.entity.isKnownEmpty then None
-                else Option(m.entity.contentType.toString)
-              case "content-length" =>
-                if m.entity.isKnownEmpty then Some("0")
-                else m.entity.contentLengthOption.map(_.toString)
-              // todo: need to adapt for multiple headers
-              case _ =>
-                import scala.jdk.OptionConverters.*
-                m.getHeader(name).toScala.nn.map(_.value.nn)
+            val m = msg.asInstanceOf[HttpMessage]
+            name.toLowerCase(java.util.Locale.ENGLISH) match
+               case "content-type" =>
+                 if m.entity.isKnownEmpty then None
+                 else Option(m.entity.contentType.toString)
+               case "content-length" =>
+                 if m.entity.isKnownEmpty then Some("0")
+                 else m.entity.contentLengthOption.map(_.toString)
+               // todo: need to adapt for multiple headers
+               case _ =>
+                 import scala.jdk.OptionConverters.*
+                 m.getHeader(name).toScala.nn.map(_.value.nn)
 
 end AkkaTp

--- a/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
@@ -17,16 +17,22 @@
 package run.cosy.akka.http
 
 import akka.http.scaladsl.model
-import akka.http.scaladsl.model.{HttpHeader, HttpMessage}
+import akka.http.scaladsl.model.{HttpHeader, HttpMessage, HttpRequest, HttpResponse}
 import akka.http.scaladsl.model.headers.RawHeader
 import run.cosy.http.{Http, HttpOps}
 import akka.http.scaladsl.model as ak
+import cats.effect.IO
 
 object AkkaTp extends Http:
    override type Message[F[_]]  = model.HttpMessage
    override type Request[F[_]]  = model.HttpRequest
    override type Response[F[_]] = model.HttpResponse
    override type Header         = model.HttpHeader
+
+   given Conversion[model.HttpRequest, Http.Request[IO,H4]] with
+     def apply(req: HttpRequest): Http.Request[IO,H4] = req.asInstanceOf[Http.Request[IO,H4]]
+   given Conversion[model.HttpResponse, Http.Response[IO,H4]] with
+     def apply(req: HttpResponse): Http.Response[IO,H4] = req.asInstanceOf[Http.Response[IO,H4]]
 
    given httpOps: HttpOps[H4] with
 

--- a/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/AkkaTp.scala
@@ -29,10 +29,10 @@ object AkkaTp extends Http:
    override type Response[F[_]] = model.HttpResponse
    override type Header         = model.HttpHeader
 
-   given Conversion[model.HttpRequest, Http.Request[IO,HT]] with
-     def apply(req: HttpRequest): Http.Request[IO,HT] = req.asInstanceOf[Http.Request[IO,HT]]
-   given Conversion[model.HttpResponse, Http.Response[IO,HT]] with
-     def apply(req: HttpResponse): Http.Response[IO,HT] = req.asInstanceOf[Http.Response[IO,HT]]
+   given Conversion[model.HttpRequest, Http.Request[IO, HT]] with
+      def apply(req: HttpRequest): Http.Request[IO, HT] = req.asInstanceOf[Http.Request[IO, HT]]
+   given Conversion[model.HttpResponse, Http.Response[IO, HT]] with
+      def apply(req: HttpResponse): Http.Response[IO, HT] = req.asInstanceOf[Http.Response[IO, HT]]
 
    given hOps: HttpOps[HT] with
 

--- a/akka/src/main/scala/run/cosy/akka/http/headers/AkkaHeaderSelector.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/headers/AkkaHeaderSelector.scala
@@ -37,12 +37,12 @@ import java.util.Locale
 import scala.collection.immutable.ListMap
 import scala.util.{Failure, Success, Try}
 import cats.Id
-import run.cosy.akka.http.AkkaTp.H4
+import run.cosy.akka.http.AkkaTp.HT as AH
 import akka.http.scaladsl.model as ak
 import cats.effect.*
 
 /** Selectors that work on headers but take no parameters. */
-trait AkkaBasicHeaderSelector[HM <: Http.Message[IO, H4]]
+trait AkkaBasicHeaderSelector[HM <: Http.Message[IO, AH]]
     extends BasicMessageSelector[HM] with AkkaHeaderSelector[HM]:
 
    override def lowercaseHeaderName: String = lowercaseName
@@ -51,7 +51,7 @@ trait AkkaBasicHeaderSelector[HM <: Http.Message[IO, H4]]
 
 /** Akka's builtin header parsers have specialised parsers for the most well known headers.
   */
-trait TypedAkkaSelector[HM <: Http.Message[IO, H4], HdrType <: HttpHeader: scala.reflect.ClassTag]
+trait TypedAkkaSelector[HM <: Http.Message[IO, AH], HdrType <: HttpHeader: scala.reflect.ClassTag]
     extends AkkaBasicHeaderSelector[HM]:
    override val lowercaseName: String = akkaCompanion.lowercaseName
    def akkaCompanion: ModeledCompanion[HdrType]
@@ -65,7 +65,7 @@ trait TypedAkkaSelector[HM <: Http.Message[IO, H4], HdrType <: HttpHeader: scala
          case head :: tail => Success(NonEmptyList(head, tail))
 
 //todo: the type IO is arbitrary for Akka. Currently using it because of tests, which is not right
-trait AkkaHeaderSelector[HM <: Http.Message[IO, H4]] extends HeaderSelector[HM]:
+trait AkkaHeaderSelector[HM <: Http.Message[IO, AH]] extends HeaderSelector[HM]:
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
       val m = msg.asInstanceOf[ak.HttpMessage]
       val headersValues: Seq[String] = m.headers
@@ -78,10 +78,10 @@ trait AkkaHeaderSelector[HM <: Http.Message[IO, H4]] extends HeaderSelector[HM]:
          case head :: tail => Success(NonEmptyList(head, tail))
 
 /** for all headers for which Akka HTTP does not provide a built-in parser */
-trait UntypedAkkaSelector[HM <: Http.Message[IO, H4]]
+trait UntypedAkkaSelector[HM <: Http.Message[IO, AH]]
     extends AkkaBasicHeaderSelector[HM] with AkkaHeaderSelector[HM]
 
 /** todo: the UntypedAkkaSelector inheritance may not be long term */
-trait AkkaDictSelector[HM <: Http.Message[IO, H4]]
+trait AkkaDictSelector[HM <: Http.Message[IO, AH]]
     extends DictSelector[HM] with AkkaHeaderSelector[HM]:
    override def lowercaseHeaderName: String = lowercaseName

--- a/akka/src/main/scala/run/cosy/akka/http/headers/AkkaHeaderSelector.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/headers/AkkaHeaderSelector.scala
@@ -22,7 +22,12 @@ import akka.http.scaladsl.model.headers.*
 import cats.data.NonEmptyList
 import run.cosy.akka.http.headers.BetterCustomHeader
 import run.cosy.http.Http
-import run.cosy.http.auth.{AttributeMissingException, HTTPHeaderParseException, SelectorException, UnableToCreateSigHeaderException}
+import run.cosy.http.auth.{
+  AttributeMissingException,
+  HTTPHeaderParseException,
+  SelectorException,
+  UnableToCreateSigHeaderException
+}
 import run.cosy.http.headers.Rfc8941.Serialise.given
 import run.cosy.http.headers.Rfc8941.{PItem, Params, Serialise, SfDict, SfString}
 import run.cosy.http.headers.*
@@ -37,7 +42,7 @@ import akka.http.scaladsl.model as ak
 import cats.effect.*
 
 /** Selectors that work on headers but take no parameters. */
-trait AkkaBasicHeaderSelector[HM <: Http.Message[IO,H4]]
+trait AkkaBasicHeaderSelector[HM <: Http.Message[IO, H4]]
     extends BasicMessageSelector[HM] with AkkaHeaderSelector[HM]:
 
    override def lowercaseHeaderName: String = lowercaseName
@@ -46,12 +51,12 @@ trait AkkaBasicHeaderSelector[HM <: Http.Message[IO,H4]]
 
 /** Akka's builtin header parsers have specialised parsers for the most well known headers.
   */
-trait TypedAkkaSelector[HM <: Http.Message[IO,H4], HdrType <: HttpHeader: scala.reflect.ClassTag]
+trait TypedAkkaSelector[HM <: Http.Message[IO, H4], HdrType <: HttpHeader: scala.reflect.ClassTag]
     extends AkkaBasicHeaderSelector[HM]:
    override val lowercaseName: String = akkaCompanion.lowercaseName
    def akkaCompanion: ModeledCompanion[HdrType]
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
-      val m = msg.asInstanceOf[ak.HttpMessage]
+      val m                         = msg.asInstanceOf[ak.HttpMessage]
       val headerValues: Seq[String] = m.headers[HdrType].map(_.value())
       headerValues match
          case Seq() => Failure(UnableToCreateSigHeaderException(
@@ -60,7 +65,7 @@ trait TypedAkkaSelector[HM <: Http.Message[IO,H4], HdrType <: HttpHeader: scala.
          case head :: tail => Success(NonEmptyList(head, tail))
 
 //todo: the type IO is arbitrary for Akka. Currently using it because of tests, which is not right
-trait AkkaHeaderSelector[HM <: Http.Message[IO,H4]] extends HeaderSelector[HM]:
+trait AkkaHeaderSelector[HM <: Http.Message[IO, H4]] extends HeaderSelector[HM]:
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
       val m = msg.asInstanceOf[ak.HttpMessage]
       val headersValues: Seq[String] = m.headers

--- a/akka/src/main/scala/run/cosy/akka/http/headers/AkkaHeaderSelector.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/headers/AkkaHeaderSelector.scala
@@ -21,12 +21,8 @@ import akka.http.scaladsl.model.ContentTypes.NoContentType
 import akka.http.scaladsl.model.headers.*
 import cats.data.NonEmptyList
 import run.cosy.akka.http.headers.BetterCustomHeader
-import run.cosy.http.auth.{
-  AttributeMissingException,
-  HTTPHeaderParseException,
-  SelectorException,
-  UnableToCreateSigHeaderException
-}
+import run.cosy.http.Http
+import run.cosy.http.auth.{AttributeMissingException, HTTPHeaderParseException, SelectorException, UnableToCreateSigHeaderException}
 import run.cosy.http.headers.Rfc8941.Serialise.given
 import run.cosy.http.headers.Rfc8941.{PItem, Params, Serialise, SfDict, SfString}
 import run.cosy.http.headers.*
@@ -35,9 +31,13 @@ import java.nio.charset.Charset
 import java.util.Locale
 import scala.collection.immutable.ListMap
 import scala.util.{Failure, Success, Try}
+import cats.Id
+import run.cosy.akka.http.AkkaTp.H4
+import akka.http.scaladsl.model as ak
+import cats.effect.*
 
 /** Selectors that work on headers but take no parameters. */
-trait AkkaBasicHeaderSelector[HM <: HttpMessage]
+trait AkkaBasicHeaderSelector[HM <: Http.Message[IO,H4]]
     extends BasicMessageSelector[HM] with AkkaHeaderSelector[HM]:
 
    override def lowercaseHeaderName: String = lowercaseName
@@ -46,21 +46,24 @@ trait AkkaBasicHeaderSelector[HM <: HttpMessage]
 
 /** Akka's builtin header parsers have specialised parsers for the most well known headers.
   */
-trait TypedAkkaSelector[HM <: HttpMessage, HdrType <: HttpHeader: scala.reflect.ClassTag]
+trait TypedAkkaSelector[HM <: Http.Message[IO,H4], HdrType <: HttpHeader: scala.reflect.ClassTag]
     extends AkkaBasicHeaderSelector[HM]:
    override val lowercaseName: String = akkaCompanion.lowercaseName
    def akkaCompanion: ModeledCompanion[HdrType]
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
-      val headerValues: Seq[String] = msg.headers[HdrType].map(_.value())
+      val m = msg.asInstanceOf[ak.HttpMessage]
+      val headerValues: Seq[String] = m.headers[HdrType].map(_.value())
       headerValues match
          case Seq() => Failure(UnableToCreateSigHeaderException(
              s"No headers »$lowercaseHeaderName« in http message"
            ))
          case head :: tail => Success(NonEmptyList(head, tail))
 
-trait AkkaHeaderSelector[HM <: HttpMessage] extends HeaderSelector[HM]:
+//todo: the type IO is arbitrary for Akka. Currently using it because of tests, which is not right
+trait AkkaHeaderSelector[HM <: Http.Message[IO,H4]] extends HeaderSelector[HM]:
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
-      val headersValues: Seq[String] = msg.headers
+      val m = msg.asInstanceOf[ak.HttpMessage]
+      val headersValues: Seq[String] = m.headers
         .filter(_.lowercaseName() == lowercaseHeaderName)
         .map(_.value())
       headersValues match
@@ -70,10 +73,10 @@ trait AkkaHeaderSelector[HM <: HttpMessage] extends HeaderSelector[HM]:
          case head :: tail => Success(NonEmptyList(head, tail))
 
 /** for all headers for which Akka HTTP does not provide a built-in parser */
-trait UntypedAkkaSelector[HM <: HttpMessage]
+trait UntypedAkkaSelector[HM <: Http.Message[IO, H4]]
     extends AkkaBasicHeaderSelector[HM] with AkkaHeaderSelector[HM]
 
 /** todo: the UntypedAkkaSelector inheritance may not be long term */
-trait AkkaDictSelector[HM <: HttpMessage]
+trait AkkaDictSelector[HM <: Http.Message[IO, H4]]
     extends DictSelector[HM] with AkkaHeaderSelector[HM]:
    override def lowercaseHeaderName: String = lowercaseName

--- a/akka/src/main/scala/run/cosy/akka/http/headers/AkkaMessageSelectors.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/headers/AkkaMessageSelectors.scala
@@ -39,37 +39,37 @@ import java.nio.charset.Charset
 import java.util.Locale
 import scala.util.{Failure, Success, Try}
 import run.cosy.http.Http
-import run.cosy.akka.http.AkkaTp.H4
+import run.cosy.akka.http.AkkaTp.HT
 
 class AkkaMessageSelectors[F[_]](
     val securedConnection: Boolean,
     val defaultHost: akka.http.scaladsl.model.Uri.Host,
     val defaultPort: Int
-) extends MessageSelectors[F, H4]:
+) extends MessageSelectors[F, HT]:
    import Http.*
 
-   override lazy val authorization: MessageSelector[Http.Request[F, H4]] =
-     new TypedAkkaSelector[Http.Request[F, H4], Authorization]:
+   override lazy val authorization: MessageSelector[Http.Request[F, HT]] =
+     new TypedAkkaSelector[Http.Request[F, HT], Authorization]:
         def akkaCompanion = Authorization
-   override lazy val `cache-control`: MessageSelector[Http.Message[F, H4]] =
-     new TypedAkkaSelector[Http.Message[F, H4], `Cache-Control`]:
+   override lazy val `cache-control`: MessageSelector[Http.Message[F, HT]] =
+     new TypedAkkaSelector[Http.Message[F, HT], `Cache-Control`]:
         def akkaCompanion = `Cache-Control`
-   override lazy val date: MessageSelector[Http.Message[F, H4]] =
-     new TypedAkkaSelector[Http.Message[F, H4], Date]:
+   override lazy val date: MessageSelector[Http.Message[F, HT]] =
+     new TypedAkkaSelector[Http.Message[F, HT], Date]:
         def akkaCompanion = Date
-   override lazy val etag: MessageSelector[Http.Response[F, H4]] =
-     new TypedAkkaSelector[Http.Response[F, H4], ETag]:
+   override lazy val etag: MessageSelector[Http.Response[F, HT]] =
+     new TypedAkkaSelector[Http.Response[F, HT], ETag]:
         def akkaCompanion = ETag
-   override lazy val host: MessageSelector[Http.Request[F, H4]] =
-     new TypedAkkaSelector[Http.Request[F, H4], Host]:
+   override lazy val host: MessageSelector[Http.Request[F, HT]] =
+     new TypedAkkaSelector[Http.Request[F, HT], Host]:
         def akkaCompanion = Host
-   override lazy val signature: DictSelector[Http.Message[F, H4]] =
-     new AkkaDictSelector[Http.Message[F, H4]]:
+   override lazy val signature: DictSelector[Http.Message[F, HT]] =
+     new AkkaDictSelector[Http.Message[F, HT]]:
         override val lowercaseName: String = "signature"
-   override lazy val `content-type`: MessageSelector[Http.Message[F, H4]] =
-     new UntypedAkkaSelector[Http.Message[F, H4]]:
+   override lazy val `content-type`: MessageSelector[Http.Message[F, HT]] =
+     new UntypedAkkaSelector[Http.Message[F, HT]]:
         override val lowercaseName: String = "content-type"
-        override def signingString(msg: Http.Message[F, H4], params: Rfc8941.Params): Try[String] =
+        override def signingString(msg: Http.Message[F, HT], params: Rfc8941.Params): Try[String] =
           if params.isEmpty then
              val m = msg.asInstanceOf[HttpMessage]
              m.entity.contentType match
@@ -81,10 +81,10 @@ class AkkaMessageSelectors[F[_]](
              Failure(SelectorException(
                s"selector $lowercaseName does not take parameters. Received " + params
              ))
-   override lazy val `content-length`: MessageSelector[Http.Message[F, H4]] =
-     new UntypedAkkaSelector[Http.Message[F, H4]]:
+   override lazy val `content-length`: MessageSelector[Http.Message[F, HT]] =
+     new UntypedAkkaSelector[Http.Message[F, HT]]:
         override val lowercaseName: String = "content-length"
-        override def signingString(msg: Http.Message[F, H4], params: Rfc8941.Params): Try[String] =
+        override def signingString(msg: Http.Message[F, HT], params: Rfc8941.Params): Try[String] =
            val m = msg.asInstanceOf[HttpMessage]
            if params.isEmpty then
               m.entity.contentLengthOption match
@@ -96,50 +96,50 @@ class AkkaMessageSelectors[F[_]](
               Failure(SelectorException(
                 s"selector $lowercaseName does not take parameters. Received " + params
               ))
-   override lazy val `client-cert`: MessageSelector[Http.Message[F, H4]] =
-     new UntypedAkkaSelector[Http.Message[F, H4]]:
+   override lazy val `client-cert`: MessageSelector[Http.Message[F, HT]] =
+     new UntypedAkkaSelector[Http.Message[F, HT]]:
         override val lowercaseName: String = "client-cert"
 
-   override lazy val digest: MessageSelector[Http.Message[F, H4]] =
-     new UntypedAkkaSelector[Http.Message[F, H4]]:
+   override lazy val digest: MessageSelector[Http.Message[F, HT]] =
+     new UntypedAkkaSelector[Http.Message[F, HT]]:
         override val lowercaseName: String = "digest"
-   override lazy val forwarded: MessageSelector[Http.Message[F, H4]] =
-     new UntypedAkkaSelector[Http.Message[F, H4]]:
+   override lazy val forwarded: MessageSelector[Http.Message[F, HT]] =
+     new UntypedAkkaSelector[Http.Message[F, HT]]:
         override val lowercaseName: String = "forwarded"
-   override lazy val `@request-target`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@request-target`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         override val lowercaseName: String       = "@request-target"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+        override protected def signingStringValue(req: Http.Request[F, HT]): Try[String] =
            val r = req.asInstanceOf[HttpRequest]
            Try(r.uri.toString()) // tests needed with connnect
         //		req.method match
         //		case HttpMethods.CONNECT => Failure(UnableToCreateSigHeaderException("Akka cannot correctly prcess @request-target on CONNECT requests"))
         //		case _ => Success(s""""$lowercaseName": ${req.uri}""")
-   override lazy val `@method`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@method`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         override def lowercaseName: String       = "@method"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+        override protected def signingStringValue(req: Http.Request[F, HT]): Try[String] =
            val r = req.asInstanceOf[HttpRequest]
            Success(r.method.value) // already uppercase
-   override lazy val `@target-uri`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@target-uri`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         override def lowercaseName: String       = "@target-uri"
         override def specialForRequests: Boolean = true
-        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+        override protected def signingStringValue(req: Http.Request[F, HT]): Try[String] =
            val r = req.asInstanceOf[HttpRequest]
            Success(r.effectiveUri(securedConnection, defaultHostHeader).toString())
 
-   override lazy val `@authority`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@authority`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         override def lowercaseName: String       = "@authority"
         override def specialForRequests: Boolean = true
 
         // todo: inefficient as it builds whole URI to extract only a small piece
-        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+        override protected def signingStringValue(req: Http.Request[F, HT]): Try[String] =
            val r = req.asInstanceOf[HttpRequest]
            Try(r.effectiveUri(true, defaultHostHeader)
              .authority.toString().toLowerCase(Locale.US).nn // is locale correct?
@@ -152,49 +152,49 @@ class AkkaMessageSelectors[F[_]](
         else defaultPort
       Host(defaultHost, p)
 
-   override lazy val `@scheme`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@scheme`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         override def lowercaseName: String       = "@scheme"
         override def specialForRequests: Boolean = true
 
         // todo: inefficient as it builds whole URI to extract only a small piece
-        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] = Success(
+        override protected def signingStringValue(msg: Http.Request[F, HT]): Try[String] = Success(
           if securedConnection then "https" else "http"
         )
-   override lazy val `@path`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@path`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         override def lowercaseName: String       = "@path"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+        override protected def signingStringValue(req: Http.Request[F, HT]): Try[String] =
            val r = req.asInstanceOf[HttpRequest]
            Try(r.uri.path.toString())
-   override lazy val `@status`: BasicMessageSelector[Http.Response[F, H4]] =
-     new BasicMessageSelector[Http.Response[F, H4]]:
+   override lazy val `@status`: BasicMessageSelector[Http.Response[F, HT]] =
+     new BasicMessageSelector[Http.Response[F, HT]]:
         override def lowercaseName: String = "@status"
 
-        override protected def signingStringValue(res: Http.Response[F, H4]): Try[String] =
+        override protected def signingStringValue(res: Http.Response[F, HT]): Try[String] =
            val r = res.asInstanceOf[HttpResponse]
            Try("" + r.status.intValue())
 
-   override lazy val `@query`: BasicMessageSelector[Http.Request[F, H4]] =
-     new BasicMessageSelector[Http.Request[F, H4]]:
+   override lazy val `@query`: BasicMessageSelector[Http.Request[F, HT]] =
+     new BasicMessageSelector[Http.Request[F, HT]]:
         val ASCII: Charset                       = Charset.forName("ASCII").nn
         override def lowercaseName: String       = "@query"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+        override protected def signingStringValue(req: Http.Request[F, HT]): Try[String] =
            val r = req.asInstanceOf[HttpRequest]
            Try(r.uri.queryString(ASCII).map("?" + _).getOrElse(""))
 
-   override lazy val `@query-params`: MessageSelector[Http.Request[F, H4]] =
-     new MessageSelector[Http.Request[F, H4]]:
+   override lazy val `@query-params`: MessageSelector[Http.Request[F, HT]] =
+     new MessageSelector[Http.Request[F, HT]]:
         val nameParam: Rfc8941.Token             = Rfc8941.Token("name")
         val ASCII: Charset                       = Charset.forName("ASCII").nn
         override def lowercaseName: String       = "@query-params"
         override def specialForRequests: Boolean = true
 
-        override def signingString(req: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
+        override def signingString(req: Http.Request[F, HT], params: Rfc8941.Params): Try[String] =
           params.toSeq match
              case Seq(nameParam -> (value: Rfc8941.SfString)) => Try {
                  val r        = req.asInstanceOf[HttpRequest]
@@ -206,13 +206,13 @@ class AkkaMessageSelectors[F[_]](
                    s"selector $lowercaseName only takes ${nameParam.canon} parameters. Received " + params
                  )
                )
-   override lazy val `@request-response`: MessageSelector[Http.Request[F, H4]] =
-     new MessageSelector[Http.Request[F, H4]]:
+   override lazy val `@request-response`: MessageSelector[Http.Request[F, HT]] =
+     new MessageSelector[Http.Request[F, HT]]:
         val keyParam: Rfc8941.Token              = Rfc8941.Token("key")
         override def lowercaseName: String       = "@request-response"
         override def specialForRequests: Boolean = true
 
-        override def signingString(msg: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
+        override def signingString(msg: Http.Request[F, HT], params: Rfc8941.Params): Try[String] =
           params.toSeq match
              case Seq(keyParam -> (value: Rfc8941.SfString)) => signingStringFor(msg, value)
              case _ => Failure(
@@ -222,7 +222,7 @@ class AkkaMessageSelectors[F[_]](
                )
 
         protected def signingStringFor(
-            msg: Http.Request[F, H4],
+            msg: Http.Request[F, HT],
             key: Rfc8941.SfString
         ): Try[String] =
           for

--- a/akka/src/main/scala/run/cosy/akka/http/headers/AkkaMessageSelectors.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/headers/AkkaMessageSelectors.scala
@@ -47,7 +47,7 @@ class AkkaMessageSelectors[F[_]](
     val defaultPort: Int
 ) extends MessageSelectors[F, H4]:
    import Http.*
-   
+
    override lazy val authorization: MessageSelector[Http.Request[F, H4]] =
      new TypedAkkaSelector[Http.Request[F, H4], Authorization]:
         def akkaCompanion = Authorization
@@ -85,17 +85,17 @@ class AkkaMessageSelectors[F[_]](
      new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "content-length"
         override def signingString(msg: Http.Message[F, H4], params: Rfc8941.Params): Try[String] =
-          val m = msg.asInstanceOf[HttpMessage]
-          if params.isEmpty then
-             m.entity.contentLengthOption match
-                case None => Failure(
-                    UnableToCreateSigHeaderException(s"""No header '$lowercaseName' in request""")
-                  )
-                case Some(cl) => Success(s""""$lowercaseName": $cl""")
-          else
-             Failure(SelectorException(
-               s"selector $lowercaseName does not take parameters. Received " + params
-             ))
+           val m = msg.asInstanceOf[HttpMessage]
+           if params.isEmpty then
+              m.entity.contentLengthOption match
+                 case None => Failure(
+                     UnableToCreateSigHeaderException(s"""No header '$lowercaseName' in request""")
+                   )
+                 case Some(cl) => Success(s""""$lowercaseName": $cl""")
+           else
+              Failure(SelectorException(
+                s"selector $lowercaseName does not take parameters. Received " + params
+              ))
    override lazy val `client-cert`: MessageSelector[Http.Message[F, H4]] =
      new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "client-cert"
@@ -112,8 +112,8 @@ class AkkaMessageSelectors[F[_]](
         override def specialForRequests: Boolean = true
 
         override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
-          val r = req.asInstanceOf[HttpRequest]
-          Try(r.uri.toString()) // tests needed with connnect
+           val r = req.asInstanceOf[HttpRequest]
+           Try(r.uri.toString()) // tests needed with connnect
         //		req.method match
         //		case HttpMethods.CONNECT => Failure(UnableToCreateSigHeaderException("Akka cannot correctly prcess @request-target on CONNECT requests"))
         //		case _ => Success(s""""$lowercaseName": ${req.uri}""")
@@ -123,15 +123,15 @@ class AkkaMessageSelectors[F[_]](
         override def specialForRequests: Boolean = true
 
         override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
-          val r = req.asInstanceOf[HttpRequest]
-          Success(r.method.value) // already uppercase
+           val r = req.asInstanceOf[HttpRequest]
+           Success(r.method.value) // already uppercase
    override lazy val `@target-uri`: BasicMessageSelector[Http.Request[F, H4]] =
      new BasicMessageSelector[Http.Request[F, H4]]:
         override def lowercaseName: String       = "@target-uri"
         override def specialForRequests: Boolean = true
         override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
-          val r = req.asInstanceOf[HttpRequest]
-          Success(r.effectiveUri(securedConnection, defaultHostHeader).toString())
+           val r = req.asInstanceOf[HttpRequest]
+           Success(r.effectiveUri(securedConnection, defaultHostHeader).toString())
 
    override lazy val `@authority`: BasicMessageSelector[Http.Request[F, H4]] =
      new BasicMessageSelector[Http.Request[F, H4]]:
@@ -140,10 +140,10 @@ class AkkaMessageSelectors[F[_]](
 
         // todo: inefficient as it builds whole URI to extract only a small piece
         override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
-          val r = req.asInstanceOf[HttpRequest]
-          Try(r.effectiveUri(true, defaultHostHeader)
-            .authority.toString().toLowerCase(Locale.US).nn // is locale correct?
-          )
+           val r = req.asInstanceOf[HttpRequest]
+           Try(r.effectiveUri(true, defaultHostHeader)
+             .authority.toString().toLowerCase(Locale.US).nn // is locale correct?
+           )
    private lazy val defaultHostHeader =
       val p =
         if defaultPort == 0 then 0
@@ -167,15 +167,15 @@ class AkkaMessageSelectors[F[_]](
         override def specialForRequests: Boolean = true
 
         override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
-          val r = req.asInstanceOf[HttpRequest]
-          Try(r.uri.path.toString())
+           val r = req.asInstanceOf[HttpRequest]
+           Try(r.uri.path.toString())
    override lazy val `@status`: BasicMessageSelector[Http.Response[F, H4]] =
      new BasicMessageSelector[Http.Response[F, H4]]:
         override def lowercaseName: String = "@status"
 
         override protected def signingStringValue(res: Http.Response[F, H4]): Try[String] =
-          val r = res.asInstanceOf[HttpResponse]
-          Try("" + r.status.intValue())
+           val r = res.asInstanceOf[HttpResponse]
+           Try("" + r.status.intValue())
 
    override lazy val `@query`: BasicMessageSelector[Http.Request[F, H4]] =
      new BasicMessageSelector[Http.Request[F, H4]]:
@@ -184,8 +184,8 @@ class AkkaMessageSelectors[F[_]](
         override def specialForRequests: Boolean = true
 
         override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
-          val r = req.asInstanceOf[HttpRequest]
-          Try(r.uri.queryString(ASCII).map("?" + _).getOrElse(""))
+           val r = req.asInstanceOf[HttpRequest]
+           Try(r.uri.queryString(ASCII).map("?" + _).getOrElse(""))
 
    override lazy val `@query-params`: MessageSelector[Http.Request[F, H4]] =
      new MessageSelector[Http.Request[F, H4]]:
@@ -197,8 +197,8 @@ class AkkaMessageSelectors[F[_]](
         override def signingString(req: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
           params.toSeq match
              case Seq(nameParam -> (value: Rfc8941.SfString)) => Try {
-               val r = req.asInstanceOf[HttpRequest]
-               val queryStr = r.uri.query().get(value.asciiStr).getOrElse("")
+                 val r        = req.asInstanceOf[HttpRequest]
+                 val queryStr = r.uri.query().get(value.asciiStr).getOrElse("")
                  s""""$lowercaseName";name=${value.canon}: $queryStr"""
                }
              case _ => Failure(
@@ -221,7 +221,10 @@ class AkkaMessageSelectors[F[_]](
                  )
                )
 
-        protected def signingStringFor(msg: Http.Request[F, H4], key: Rfc8941.SfString): Try[String] =
+        protected def signingStringFor(
+            msg: Http.Request[F, H4],
+            key: Rfc8941.SfString
+        ): Try[String] =
           for
              sigsDict <- signature.sfDictParse(msg)
              keyStr   <- Try(Rfc8941.Token(key.asciiStr))

--- a/akka/src/main/scala/run/cosy/akka/http/headers/AkkaMessageSelectors.scala
+++ b/akka/src/main/scala/run/cosy/akka/http/headers/AkkaMessageSelectors.scala
@@ -39,39 +39,40 @@ import java.nio.charset.Charset
 import java.util.Locale
 import scala.util.{Failure, Success, Try}
 import run.cosy.http.Http
+import run.cosy.akka.http.AkkaTp.H4
 
-class AkkaMessageSelectors(
+class AkkaMessageSelectors[F[_]](
     val securedConnection: Boolean,
     val defaultHost: akka.http.scaladsl.model.Uri.Host,
     val defaultPort: Int
-) extends MessageSelectors[AkkaTp.type]:
+) extends MessageSelectors[F, H4]:
    import Http.*
-   type A = AkkaTp.type
-
-   override lazy val authorization: MessageSelector[Request[A]] =
-     new TypedAkkaSelector[Request[A], Authorization]:
+   
+   override lazy val authorization: MessageSelector[Http.Request[F, H4]] =
+     new TypedAkkaSelector[Http.Request[F, H4], Authorization]:
         def akkaCompanion = Authorization
-   override lazy val `cache-control`: MessageSelector[Message[A]] =
-     new TypedAkkaSelector[Message[A], `Cache-Control`]:
+   override lazy val `cache-control`: MessageSelector[Http.Message[F, H4]] =
+     new TypedAkkaSelector[Http.Message[F, H4], `Cache-Control`]:
         def akkaCompanion = `Cache-Control`
-   override lazy val date: MessageSelector[Message[A]] =
-     new TypedAkkaSelector[Message[A], Date]:
+   override lazy val date: MessageSelector[Http.Message[F, H4]] =
+     new TypedAkkaSelector[Http.Message[F, H4], Date]:
         def akkaCompanion = Date
-   override lazy val etag: MessageSelector[Response[A]] =
-     new TypedAkkaSelector[Response[A], ETag]:
+   override lazy val etag: MessageSelector[Http.Response[F, H4]] =
+     new TypedAkkaSelector[Http.Response[F, H4], ETag]:
         def akkaCompanion = ETag
-   override lazy val host: MessageSelector[Request[A]] =
-     new TypedAkkaSelector[Request[A], Host]:
+   override lazy val host: MessageSelector[Http.Request[F, H4]] =
+     new TypedAkkaSelector[Http.Request[F, H4], Host]:
         def akkaCompanion = Host
-   override lazy val signature: DictSelector[Message[A]] =
-     new AkkaDictSelector[Message[A]]:
+   override lazy val signature: DictSelector[Http.Message[F, H4]] =
+     new AkkaDictSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "signature"
-   override lazy val `content-type`: MessageSelector[Message[A]] =
-     new UntypedAkkaSelector[Message[A]]:
+   override lazy val `content-type`: MessageSelector[Http.Message[F, H4]] =
+     new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "content-type"
-        override def signingString(msg: Message[A], params: Rfc8941.Params): Try[String] =
+        override def signingString(msg: Http.Message[F, H4], params: Rfc8941.Params): Try[String] =
           if params.isEmpty then
-             msg.entity.contentType match
+             val m = msg.asInstanceOf[HttpMessage]
+             m.entity.contentType match
                 case NoContentType => Failure(
                     UnableToCreateSigHeaderException(s"""No header '$lowercaseName' in request""")
                   )
@@ -80,12 +81,13 @@ class AkkaMessageSelectors(
              Failure(SelectorException(
                s"selector $lowercaseName does not take parameters. Received " + params
              ))
-   override lazy val `content-length`: MessageSelector[Message[A]] =
-     new UntypedAkkaSelector[Message[A]]:
+   override lazy val `content-length`: MessageSelector[Http.Message[F, H4]] =
+     new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "content-length"
-        override def signingString(msg: Message[A], params: Rfc8941.Params): Try[String] =
+        override def signingString(msg: Http.Message[F, H4], params: Rfc8941.Params): Try[String] =
+          val m = msg.asInstanceOf[HttpMessage]
           if params.isEmpty then
-             msg.entity.contentLengthOption match
+             m.entity.contentLengthOption match
                 case None => Failure(
                     UnableToCreateSigHeaderException(s"""No header '$lowercaseName' in request""")
                   )
@@ -94,50 +96,54 @@ class AkkaMessageSelectors(
              Failure(SelectorException(
                s"selector $lowercaseName does not take parameters. Received " + params
              ))
-   override lazy val `client-cert`: MessageSelector[Message[A]] =
-     new UntypedAkkaSelector[Message[A]]:
+   override lazy val `client-cert`: MessageSelector[Http.Message[F, H4]] =
+     new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "client-cert"
 
-   override lazy val digest: MessageSelector[Message[A]] =
-     new UntypedAkkaSelector[Message[A]]:
+   override lazy val digest: MessageSelector[Http.Message[F, H4]] =
+     new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "digest"
-   override lazy val forwarded: MessageSelector[Message[A]] =
-     new UntypedAkkaSelector[Message[A]]:
+   override lazy val forwarded: MessageSelector[Http.Message[F, H4]] =
+     new UntypedAkkaSelector[Http.Message[F, H4]]:
         override val lowercaseName: String = "forwarded"
-   override lazy val `@request-target`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+   override lazy val `@request-target`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         override val lowercaseName: String       = "@request-target"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(req: Request[A]): Try[String] =
-          Try(req.uri.toString()) // tests needed with connnect
+        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+          val r = req.asInstanceOf[HttpRequest]
+          Try(r.uri.toString()) // tests needed with connnect
         //		req.method match
         //		case HttpMethods.CONNECT => Failure(UnableToCreateSigHeaderException("Akka cannot correctly prcess @request-target on CONNECT requests"))
         //		case _ => Success(s""""$lowercaseName": ${req.uri}""")
-   override lazy val `@method`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+   override lazy val `@method`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         override def lowercaseName: String       = "@method"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(msg: Request[A]): Try[String] =
-          Success(msg.method.value) // already uppercase
-   override lazy val `@target-uri`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+          val r = req.asInstanceOf[HttpRequest]
+          Success(r.method.value) // already uppercase
+   override lazy val `@target-uri`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         override def lowercaseName: String       = "@target-uri"
         override def specialForRequests: Boolean = true
-        override protected def signingStringValue(msg: Request[A]): Try[String] =
-          Success(msg.effectiveUri(securedConnection, defaultHostHeader).toString())
+        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+          val r = req.asInstanceOf[HttpRequest]
+          Success(r.effectiveUri(securedConnection, defaultHostHeader).toString())
 
-   override lazy val `@authority`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+   override lazy val `@authority`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         override def lowercaseName: String       = "@authority"
         override def specialForRequests: Boolean = true
 
         // todo: inefficient as it builds whole URI to extract only a small piece
-        override protected def signingStringValue(msg: Request[A]): Try[String] = Try(
-          msg.effectiveUri(true, defaultHostHeader)
+        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+          val r = req.asInstanceOf[HttpRequest]
+          Try(r.effectiveUri(true, defaultHostHeader)
             .authority.toString().toLowerCase(Locale.US).nn // is locale correct?
-        )
+          )
    private lazy val defaultHostHeader =
       val p =
         if defaultPort == 0 then 0
@@ -146,50 +152,53 @@ class AkkaMessageSelectors(
         else defaultPort
       Host(defaultHost, p)
 
-   override lazy val `@scheme`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+   override lazy val `@scheme`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         override def lowercaseName: String       = "@scheme"
         override def specialForRequests: Boolean = true
 
         // todo: inefficient as it builds whole URI to extract only a small piece
-        override protected def signingStringValue(msg: Request[A]): Try[String] = Success(
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] = Success(
           if securedConnection then "https" else "http"
         )
-   override lazy val `@path`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+   override lazy val `@path`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         override def lowercaseName: String       = "@path"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(msg: Request[A]): Try[String] = Try(
-          msg.uri.path.toString()
-        )
-   override lazy val `@status`: BasicMessageSelector[Response[A]] =
-     new BasicMessageSelector[Response[A]]:
+        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+          val r = req.asInstanceOf[HttpRequest]
+          Try(r.uri.path.toString())
+   override lazy val `@status`: BasicMessageSelector[Http.Response[F, H4]] =
+     new BasicMessageSelector[Http.Response[F, H4]]:
         override def lowercaseName: String = "@status"
 
-        override protected def signingStringValue(msg: Response[A]): Try[String] =
-          Try("" + msg.status.intValue())
+        override protected def signingStringValue(res: Http.Response[F, H4]): Try[String] =
+          val r = res.asInstanceOf[HttpResponse]
+          Try("" + r.status.intValue())
 
-   override lazy val `@query`: BasicMessageSelector[Request[A]] =
-     new BasicMessageSelector[Request[A]]:
+   override lazy val `@query`: BasicMessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
         val ASCII: Charset                       = Charset.forName("ASCII").nn
         override def lowercaseName: String       = "@query"
         override def specialForRequests: Boolean = true
 
-        override protected def signingStringValue(msg: Request[A]): Try[String] =
-          Try(msg.uri.queryString(ASCII).map("?" + _).getOrElse(""))
+        override protected def signingStringValue(req: Http.Request[F, H4]): Try[String] =
+          val r = req.asInstanceOf[HttpRequest]
+          Try(r.uri.queryString(ASCII).map("?" + _).getOrElse(""))
 
-   override lazy val `@query-params`: MessageSelector[Request[A]] =
-     new MessageSelector[Request[A]]:
+   override lazy val `@query-params`: MessageSelector[Http.Request[F, H4]] =
+     new MessageSelector[Http.Request[F, H4]]:
         val nameParam: Rfc8941.Token             = Rfc8941.Token("name")
         val ASCII: Charset                       = Charset.forName("ASCII").nn
         override def lowercaseName: String       = "@query-params"
         override def specialForRequests: Boolean = true
 
-        override def signingString(msg: Request[A], params: Rfc8941.Params): Try[String] =
+        override def signingString(req: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
           params.toSeq match
              case Seq(nameParam -> (value: Rfc8941.SfString)) => Try {
-                 val queryStr = msg.uri.query().get(value.asciiStr).getOrElse("")
+               val r = req.asInstanceOf[HttpRequest]
+               val queryStr = r.uri.query().get(value.asciiStr).getOrElse("")
                  s""""$lowercaseName";name=${value.canon}: $queryStr"""
                }
              case _ => Failure(
@@ -197,13 +206,13 @@ class AkkaMessageSelectors(
                    s"selector $lowercaseName only takes ${nameParam.canon} parameters. Received " + params
                  )
                )
-   override lazy val `@request-response`: MessageSelector[Request[A]] =
-     new MessageSelector[Request[A]]:
+   override lazy val `@request-response`: MessageSelector[Http.Request[F, H4]] =
+     new MessageSelector[Http.Request[F, H4]]:
         val keyParam: Rfc8941.Token              = Rfc8941.Token("key")
         override def lowercaseName: String       = "@request-response"
         override def specialForRequests: Boolean = true
 
-        override def signingString(msg: Request[A], params: Rfc8941.Params): Try[String] =
+        override def signingString(msg: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
           params.toSeq match
              case Seq(keyParam -> (value: Rfc8941.SfString)) => signingStringFor(msg, value)
              case _ => Failure(
@@ -212,7 +221,7 @@ class AkkaMessageSelectors(
                  )
                )
 
-        protected def signingStringFor(msg: Request[A], key: Rfc8941.SfString): Try[String] =
+        protected def signingStringFor(msg: Http.Request[F, H4], key: Rfc8941.SfString): Try[String] =
           for
              sigsDict <- signature.sfDictParse(msg)
              keyStr   <- Try(Rfc8941.Token(key.asciiStr))

--- a/akka/src/main/scala/run/cosy/http/auth/MessageSignature.scala
+++ b/akka/src/main/scala/run/cosy/http/auth/MessageSignature.scala
@@ -19,7 +19,7 @@ package run.cosy.http.auth
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.util.FastFuture
 import cats.Applicative
-import run.cosy.akka.http.AkkaTp
+import run.cosy.akka.http.AkkaTp.H4
 import run.cosy.http.Http.{Header, Message}
 import run.cosy.http.headers.SelectorOps
 
@@ -28,12 +28,11 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 // selector needs to be filled in
-object AkkaHttpMessageSignature extends run.cosy.http.auth.MessageSignature[AkkaTp.type]:
-   type H = AkkaTp.type
+object AkkaHttpMessageSignature extends run.cosy.http.auth.MessageSignature[H4]:
    import AkkaHttpMessageSignature.*
 //	override type Message = HttpMessage
 
-   override protected val Signature: SignatureMatcher[AkkaTp.type] =
+   override protected val Signature: SignatureMatcher[H4] =
      run.cosy.akka.http.headers.Signature
-   override protected val `Signature-Input`: SignatureInputMatcher[AkkaTp.type] =
+   override protected val `Signature-Input`: SignatureInputMatcher[H4] =
      run.cosy.akka.http.headers.`Signature-Input`

--- a/akka/src/main/scala/run/cosy/http/auth/MessageSignature.scala
+++ b/akka/src/main/scala/run/cosy/http/auth/MessageSignature.scala
@@ -19,7 +19,7 @@ package run.cosy.http.auth
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.util.FastFuture
 import cats.Applicative
-import run.cosy.akka.http.AkkaTp.H4
+import run.cosy.akka.http.AkkaTp.HT
 import run.cosy.http.Http.{Header, Message}
 import run.cosy.http.headers.SelectorOps
 
@@ -28,11 +28,11 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 // selector needs to be filled in
-object AkkaHttpMessageSignature extends run.cosy.http.auth.MessageSignature[H4]:
+object AkkaHttpMessageSignature extends run.cosy.http.auth.MessageSignature[HT]:
    import AkkaHttpMessageSignature.*
 //	override type Message = HttpMessage
 
-   override protected val Signature: SignatureMatcher[H4] =
+   override protected val Signature: SignatureMatcher[HT] =
      run.cosy.akka.http.headers.Signature
-   override protected val `Signature-Input`: SignatureInputMatcher[H4] =
+   override protected val `Signature-Input`: SignatureInputMatcher[HT] =
      run.cosy.akka.http.headers.`Signature-Input`

--- a/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
+++ b/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
@@ -19,9 +19,25 @@ package run.cosy.http.auth
 import scala.util.Success
 import akka.http.scaladsl.model.HttpMethods.*
 import akka.http.scaladsl.model.headers.*
-import akka.http.scaladsl.model.{ContentTypes, DateTime, HttpEntity, HttpMethods, HttpRequest, HttpResponse, MediaTypes, StatusCodes, Uri}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  DateTime,
+  HttpEntity,
+  HttpMethods,
+  HttpRequest,
+  HttpResponse,
+  MediaTypes,
+  StatusCodes,
+  Uri
+}
 import run.cosy.akka.http.AkkaTp
-import run.cosy.akka.http.headers.{AkkaDictSelector, AkkaMessageSelectors, Signature, UntypedAkkaSelector, `Signature-Input`}
+import run.cosy.akka.http.headers.{
+  AkkaDictSelector,
+  AkkaMessageSelectors,
+  Signature,
+  UntypedAkkaSelector,
+  `Signature-Input`
+}
 import run.cosy.http.headers.{DictSelector, Rfc8941, SigInput, SigInputs, Signatures}
 import run.cosy.http.auth.HttpMessageSigningSuite
 import run.cosy.http.Http
@@ -38,18 +54,18 @@ import cats.effect.{Async, IO}
 
 class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, H4]:
    given pem: bobcats.util.PEMUtils                       = bobcats.util.BouncyJavaPEMUtils
-   given ops: run.cosy.http.HttpOps[H4]                    = run.cosy.akka.http.AkkaTp.httpOps
+   given ops: run.cosy.http.HttpOps[H4]                   = run.cosy.akka.http.AkkaTp.httpOps
    given sigSuite: run.cosy.http.auth.SigningSuiteHelpers = new SigningSuiteHelpers
    val selectorsSecure   = AkkaMessageSelectors(true, Uri.Host("bblfish.net"), 443)
    val selectorsInSecure = AkkaMessageSelectors(false, Uri.Host("bblfish.net"), 80)
    val messageSignature: run.cosy.http.auth.MessageSignature[H4] = AkkaHttpMessageSignature
    import selectorsSecure.*
-   //todo: can scala not infer the following implicits?
-   implicit def akkaReqToGeneric(req: HttpRequest): Http.Request[IO,H4] =
-     req.asInstanceOf[Http.Request[IO,H4]]
-   implicit def akkaReqToGeneric(req: HttpResponse): Http.Response[IO,H4] =
-    req.asInstanceOf[Http.Response[IO,H4]]
-    
+   // todo: can scala not infer the following implicits?
+   implicit def akkaReqToGeneric(req: HttpRequest): Http.Request[IO, H4] =
+     req.asInstanceOf[Http.Request[IO, H4]]
+   implicit def akkaReqToGeneric(req: HttpResponse): Http.Response[IO, H4] =
+     req.asInstanceOf[Http.Response[IO, H4]]
+
    /** todo: with Akka it is possible to automatically convert a String to an HttpMessage, but it
      * requires more work, a different test suite potentially, etc... That will be needed for large
      * test suites though. See
@@ -57,7 +73,7 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, H4]:
      *   1. akka.http.impl.engine.parsing.ResponseParserSpec
      */
    @throws[Exception]
-   def toRequest(request: HttpMessage): Request[IO,H4] =
+   def toRequest(request: HttpMessage): Request[IO, H4] =
      request match
         case `§2.1.2_HeaderField` => HttpRequest(
             method = HttpMethods.GET,
@@ -177,10 +193,10 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, H4]:
 					|  r5S9IXf2fYJK+eyW4AiGVMvMcOg==:""".rfc8792single
           ): @unchecked
           val req: Request[IO, H4] = toRequest(`§2.3_Request`)
-          val newreq  = req.addHeaders(Seq(`Signature-Input`(sigIn), Signature(sig)))
+          val newreq               = req.addHeaders(Seq(`Signature-Input`(sigIn), Signature(sig)))
           newreq
         case `§4.3_Request` =>
-          val forwardedHdr    = RawHeader("Forwarded", "for=192.0.2.123")
+          val forwardedHdr         = RawHeader("Forwarded", "for=192.0.2.123")
           val req: Request[IO, H4] = toRequest(`§3.2_Request`)
           req.addHeaders(req.headers ++ Seq(forwardedHdr))
         case `§4.3_Enhanced` =>
@@ -276,15 +292,17 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, H4]:
      entity = HttpEntity(MediaTypes.`application/json`.toContentType, """{"hello": "world"}""")
    )
 
-   val `x-example`: MessageSelector[Request[IO,H4]] = new UntypedAkkaSelector[Request[IO,H4]]:
+   val `x-example`: MessageSelector[Request[IO, H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
       override val lowercaseName: String = "x-example"
-   val `x-empty-header`: MessageSelector[Request[IO,H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
-      override val lowercaseName: String = "x-empty-header"
+   val `x-empty-header`: MessageSelector[Request[IO, H4]] =
+     new UntypedAkkaSelector[Request[IO, H4]]:
+        override val lowercaseName: String = "x-empty-header"
    val `x-ows-header`: MessageSelector[Request[IO, H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
       override val lowercaseName: String = "x-ows-header"
-   val `x-obs-fold-header`: MessageSelector[Request[IO, H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
-      override val lowercaseName: String = "x-obs-fold-header"
-   val `x-dictionary`: DictSelector[Message[IO, H4]] = new AkkaDictSelector[Message[IO,  H4]]:
+   val `x-obs-fold-header`: MessageSelector[Request[IO, H4]] =
+     new UntypedAkkaSelector[Request[IO, H4]]:
+        override val lowercaseName: String = "x-obs-fold-header"
+   val `x-dictionary`: DictSelector[Message[IO, H4]] = new AkkaDictSelector[Message[IO, H4]]:
       override val lowercaseName: String = "x-dictionary"
 
    test("§2.2.6. Request Target for CONNECT (does not work for Akka)".fail) {

--- a/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
+++ b/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
@@ -19,25 +19,9 @@ package run.cosy.http.auth
 import scala.util.Success
 import akka.http.scaladsl.model.HttpMethods.*
 import akka.http.scaladsl.model.headers.*
-import akka.http.scaladsl.model.{
-  ContentTypes,
-  DateTime,
-  HttpEntity,
-  HttpMethods,
-  HttpRequest,
-  HttpResponse,
-  MediaTypes,
-  StatusCodes,
-  Uri
-}
+import akka.http.scaladsl.model.{ContentTypes, DateTime, HttpEntity, HttpMethods, HttpRequest, HttpResponse, MediaTypes, StatusCodes, Uri}
 import run.cosy.akka.http.AkkaTp
-import run.cosy.akka.http.headers.{
-  AkkaDictSelector,
-  AkkaMessageSelectors,
-  Signature,
-  UntypedAkkaSelector,
-  `Signature-Input`
-}
+import run.cosy.akka.http.headers.{AkkaDictSelector, AkkaMessageSelectors, Signature, UntypedAkkaSelector, `Signature-Input`}
 import run.cosy.http.headers.{DictSelector, Rfc8941, SigInput, SigInputs, Signatures}
 import run.cosy.http.auth.HttpMessageSigningSuite
 import run.cosy.http.Http
@@ -46,18 +30,26 @@ import run.cosy.http.utils.StringUtils.*
 import run.cosy.akka.http.headers.`Signature-Input`
 import run.cosy.http.headers.Rfc8941.*
 import run.cosy.http.headers.MessageSelector
-import scala.language.implicitConversions
 
-class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[AkkaTp.type]:
-   type A = AkkaTp.type
+import scala.language.implicitConversions
+import run.cosy.akka.http.AkkaTp.H4
+
+import cats.effect.{Async, IO}
+
+class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, H4]:
    given pem: bobcats.util.PEMUtils                       = bobcats.util.BouncyJavaPEMUtils
-   given ops: run.cosy.http.HttpOps[A]                    = run.cosy.akka.http.AkkaTp.httpOps
+   given ops: run.cosy.http.HttpOps[H4]                    = run.cosy.akka.http.AkkaTp.httpOps
    given sigSuite: run.cosy.http.auth.SigningSuiteHelpers = new SigningSuiteHelpers
    val selectorsSecure   = AkkaMessageSelectors(true, Uri.Host("bblfish.net"), 443)
    val selectorsInSecure = AkkaMessageSelectors(false, Uri.Host("bblfish.net"), 80)
-   val messageSignature: run.cosy.http.auth.MessageSignature[A] = AkkaHttpMessageSignature
+   val messageSignature: run.cosy.http.auth.MessageSignature[H4] = AkkaHttpMessageSignature
    import selectorsSecure.*
-
+   //todo: can scala not infer the following implicits?
+   implicit def akkaReqToGeneric(req: HttpRequest): Http.Request[IO,H4] =
+     req.asInstanceOf[Http.Request[IO,H4]]
+   implicit def akkaReqToGeneric(req: HttpResponse): Http.Response[IO,H4] =
+    req.asInstanceOf[Http.Response[IO,H4]]
+    
    /** todo: with Akka it is possible to automatically convert a String to an HttpMessage, but it
      * requires more work, a different test suite potentially, etc... That will be needed for large
      * test suites though. See
@@ -65,7 +57,7 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[AkkaTp.type]:
      *   1. akka.http.impl.engine.parsing.ResponseParserSpec
      */
    @throws[Exception]
-   def toRequest(request: HttpMessage): Request[A] =
+   def toRequest(request: HttpMessage): Request[IO,H4] =
      request match
         case `§2.1.2_HeaderField` => HttpRequest(
             method = HttpMethods.GET,
@@ -184,12 +176,13 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[AkkaTp.type]:
 					|  eKR2CD6IJQvacn5A4Ix5BUAVGqlyp8JYm+S/CWJi31PNUjRRCusCVRj05NrxABNFv3\
 					|  r5S9IXf2fYJK+eyW4AiGVMvMcOg==:""".rfc8792single
           ): @unchecked
-          val req: Request[A] = toRequest(`§2.3_Request`)
-          req.withHeaders(req.headers ++ Seq(`Signature-Input`(sigIn), Signature(sig)))
+          val req: Request[IO, H4] = toRequest(`§2.3_Request`)
+          val newreq  = req.addHeaders(Seq(`Signature-Input`(sigIn), Signature(sig)))
+          newreq
         case `§4.3_Request` =>
           val forwardedHdr    = RawHeader("Forwarded", "for=192.0.2.123")
-          val req: Request[A] = toRequest(`§3.2_Request`)
-          req.withHeaders(req.headers ++ Seq(forwardedHdr))
+          val req: Request[IO, H4] = toRequest(`§3.2_Request`)
+          req.addHeaders(req.headers ++ Seq(forwardedHdr))
         case `§4.3_Enhanced` =>
           // here we try raw headers
           val forwardedHdr = RawHeader("Forwarded", "for=192.0.2.123")
@@ -216,8 +209,8 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[AkkaTp.type]:
 				  |    cDHkNaavcokmq+3EBDCQTzgwLqfDmV0vLCXtDda6CNO2Zyum/pMGboCnQn/VkQ+\
 				  |    j8kSydKoFg6EbVuGbrQijth6I0dDX2/HYcJg==:""".rfc8792single
           )
-          val req: Request[A] = toRequest(`§2.3_Request`)
-          req.withHeaders(req.headers ++ Seq(forwardedHdr, sigIn, sig))
+          val req: Request[IO, H4] = toRequest(`§2.3_Request`)
+          req.addHeaders(Seq(forwardedHdr, sigIn, sig))
         case B2_test_request => HttpRequest(
             method = HttpMethods.POST,
             uri = Uri("/foo?param=value&pet=dog"),
@@ -252,7 +245,7 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[AkkaTp.type]:
         case _ => throw new Exception("no translation available for request " + request)
 
    @throws[Exception]
-   def toResponse(response: HttpMessage): Response[A] =
+   def toResponse(response: HttpMessage): Response[IO, H4] =
      response match
         case `§2.2.10_Response` => HttpResponse(StatusCodes.OK)
             .withHeaders(Date(DateTime.now))
@@ -283,15 +276,15 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[AkkaTp.type]:
      entity = HttpEntity(MediaTypes.`application/json`.toContentType, """{"hello": "world"}""")
    )
 
-   val `x-example`: MessageSelector[Request[A]] = new UntypedAkkaSelector[Request[A]]:
+   val `x-example`: MessageSelector[Request[IO,H4]] = new UntypedAkkaSelector[Request[IO,H4]]:
       override val lowercaseName: String = "x-example"
-   val `x-empty-header`: MessageSelector[Request[A]] = new UntypedAkkaSelector[Request[A]]:
+   val `x-empty-header`: MessageSelector[Request[IO,H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
       override val lowercaseName: String = "x-empty-header"
-   val `x-ows-header`: MessageSelector[Request[A]] = new UntypedAkkaSelector[Request[A]]:
+   val `x-ows-header`: MessageSelector[Request[IO, H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
       override val lowercaseName: String = "x-ows-header"
-   val `x-obs-fold-header`: MessageSelector[Request[A]] = new UntypedAkkaSelector[Request[A]]:
+   val `x-obs-fold-header`: MessageSelector[Request[IO, H4]] = new UntypedAkkaSelector[Request[IO, H4]]:
       override val lowercaseName: String = "x-obs-fold-header"
-   val `x-dictionary`: DictSelector[Message[A]] = new AkkaDictSelector[Message[A]]:
+   val `x-dictionary`: DictSelector[Message[IO, H4]] = new AkkaDictSelector[Message[IO,  H4]]:
       override val lowercaseName: String = "x-dictionary"
 
    test("§2.2.6. Request Target for CONNECT (does not work for Akka)".fail) {

--- a/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
+++ b/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
@@ -150,7 +150,7 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, AH]:
                 """KuhJjsOKCiISnKHh2rln5ZNIrkRvue0DSu5rif3g7ckTbbX7C4\
 					  |  Jp3bcGmi8zZsFRURSQTcjbHdJtN8ZXlRptLOPGHkUa/3Qov79gBeqvHNUO4bhI27p\
 					  |  4WzD1bJDG9+6ml3gkrs7rOvMtROObPuc78A95fa4+skS/t2T7OjkfsHAm/enxf1fA\
-					  |  wkk15xj0n6kmriwZfgUlOqyff0XLwuAHXFvZ+ZTyxYNoo2+EfFg4NVfqtSJch2WDY\
+                      |  wkk15xj0n6kmriwZfgUlOqyff0XLwuH4XFvZ+ZTyxYNoo2+EfFg4NVfqtSJch2WDY\
 					  |  7n/qmhZOzMfyHlggWYFnDpyP27VrzQCQg8rM1Crp6MrwGLa94v6qP8pq0sQVq2DLt\
 					  |  4NJSoRRqXTvqlWIRnexmcKXjQFVz6YSA==""".rfc8792single.base64Decode
               ))

--- a/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
+++ b/akka/src/test/scala/run/cosy/http/auth/AkkaHttpMessageSigningSuite.scala
@@ -60,11 +60,6 @@ class AkkaHttpMessageSigningSuite extends HttpMessageSigningSuite[IO, H4]:
    val selectorsInSecure = AkkaMessageSelectors(false, Uri.Host("bblfish.net"), 80)
    val messageSignature: run.cosy.http.auth.MessageSignature[H4] = AkkaHttpMessageSignature
    import selectorsSecure.*
-   // todo: can scala not infer the following implicits?
-   implicit def akkaReqToGeneric(req: HttpRequest): Http.Request[IO, H4] =
-     req.asInstanceOf[Http.Request[IO, H4]]
-   implicit def akkaReqToGeneric(req: HttpResponse): Http.Response[IO, H4] =
-     req.asInstanceOf[Http.Response[IO, H4]]
 
    /** todo: with Akka it is possible to automatically convert a String to an HttpMessage, but it
      * requires more work, a different test suite potentially, etc... That will be needed for large

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 import org.openqa.selenium.firefox.{FirefoxOptions, FirefoxProfile}
 import org.openqa.selenium.remote.server.{DriverFactory, DriverProvider}
 import org.scalajs.jsenv.selenium.SeleniumJSEnv
-import Dependencies._
-import JSEnv._
+import Dependencies.*
+import JSEnv.*
 
 name := "httpSig"
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / tlCiReleaseBranches := Seq()
 ThisBuild / tlCiReleaseTags     := false // don't publish artifacts on github
 //ThisBuild / tlSonatypeUseLegacyHost := false // TODO remove
 
-ThisBuild / crossScalaVersions := Seq("3.1.1")
+ThisBuild / crossScalaVersions := Seq("3.1.3", "3.2.0")
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(

--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,8 @@ lazy val akkaSig = project
     libraryDependencies ++= Seq(
       akka.http.value,
       akka.stream.value,
-      akka.typed.value
+      akka.typed.value,
+      cats.catsEffect.value
       //			java.nimbusDS
     ),
     libraryDependencies ++= java.bouncy

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / tlCiReleaseBranches := Seq()
 ThisBuild / tlCiReleaseTags     := false // don't publish artifacts on github
 //ThisBuild / tlSonatypeUseLegacyHost := false // TODO remove
 
-ThisBuild / crossScalaVersions := Seq("3.1.3", "3.2.0")
+ThisBuild / crossScalaVersions := Seq("3.1.3")
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import JSEnv.*
 
 name := "httpSig"
 
-ThisBuild / tlBaseVersion          := "0.2"
+ThisBuild / tlBaseVersion          := "0.3"
 ThisBuild / tlUntaggedAreSnapshots := true
 
 ThisBuild / developers := List(

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 import org.openqa.selenium.firefox.{FirefoxOptions, FirefoxProfile}
 import org.openqa.selenium.remote.server.{DriverFactory, DriverProvider}
 import org.scalajs.jsenv.selenium.SeleniumJSEnv
-import Dependencies.*
-import JSEnv.*
+import Dependencies._
+import JSEnv._
 
 name := "httpSig"
 

--- a/http4s/js/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJS.scala
+++ b/http4s/js/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJS.scala
@@ -19,9 +19,10 @@ package run.cosy.http4s.auth
 import run.cosy.http.HttpOps
 import run.cosy.http.auth.SigningSuiteHelpers
 import run.cosy.http4s.Http4sTp
+import run.cosy.http4s.Http4sTp.HT
 import cats.effect.IO
 
 class Http4sMessageSigningSuiteJS[F[_]] extends run.cosy.http4s.auth.Http4sMessageSigningSuite[F]:
    given pem: bobcats.util.PEMUtils             = bobcats.util.WebCryptoPEMUtils
-   override given ops: HttpOps[Http4sTp.type]   = Http4sTp.httpOps
+   override given ops: HttpOps[HT]   = Http4sTp.hOps
    override given sigSuite: SigningSuiteHelpers = new SigningSuiteHelpers

--- a/http4s/js/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJS.scala
+++ b/http4s/js/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJS.scala
@@ -19,8 +19,9 @@ package run.cosy.http4s.auth
 import run.cosy.http.HttpOps
 import run.cosy.http.auth.SigningSuiteHelpers
 import run.cosy.http4s.Http4sTp
+import cats.effect.IO
 
-class Http4sMessageSigningSuiteJS extends run.cosy.http4s.auth.Http4sMessageSigningSuite:
+class Http4sMessageSigningSuiteJS[F[_]] extends run.cosy.http4s.auth.Http4sMessageSigningSuite[F]:
    given pem: bobcats.util.PEMUtils             = bobcats.util.WebCryptoPEMUtils
    override given ops: HttpOps[Http4sTp.type]   = Http4sTp.httpOps
    override given sigSuite: SigningSuiteHelpers = new SigningSuiteHelpers

--- a/http4s/js/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJS.scala
+++ b/http4s/js/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJS.scala
@@ -24,5 +24,5 @@ import cats.effect.IO
 
 class Http4sMessageSigningSuiteJS[F[_]] extends run.cosy.http4s.auth.Http4sMessageSigningSuite[F]:
    given pem: bobcats.util.PEMUtils             = bobcats.util.WebCryptoPEMUtils
-   override given ops: HttpOps[HT]   = Http4sTp.hOps
+   override given ops: HttpOps[HT]              = Http4sTp.hOps
    override given sigSuite: SigningSuiteHelpers = new SigningSuiteHelpers

--- a/http4s/jvm/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJVM.scala
+++ b/http4s/jvm/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJVM.scala
@@ -19,9 +19,9 @@ package run.cosy.http4s.auth
 import run.cosy.http.HttpOps
 import run.cosy.http.auth.SigningSuiteHelpers
 import run.cosy.http4s.Http4sTp
-import run.cosy.http4s.Http4sTp.H4
+import run.cosy.http4s.Http4sTp.HT
 
 class Http4sMessageSigningSuiteJVM[F[_]] extends run.cosy.http4s.auth.Http4sMessageSigningSuite[F]:
    given pem: bobcats.util.PEMUtils             = bobcats.util.BouncyJavaPEMUtils
-   override given ops: HttpOps[H4]              = Http4sTp.httpOps
+   override given ops: HttpOps[HT]              = Http4sTp.hOps
    override given sigSuite: SigningSuiteHelpers = new SigningSuiteHelpers

--- a/http4s/jvm/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJVM.scala
+++ b/http4s/jvm/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJVM.scala
@@ -23,5 +23,5 @@ import run.cosy.http4s.Http4sTp.H4
 
 class Http4sMessageSigningSuiteJVM[F[_]] extends run.cosy.http4s.auth.Http4sMessageSigningSuite[F]:
    given pem: bobcats.util.PEMUtils             = bobcats.util.BouncyJavaPEMUtils
-   override given ops: HttpOps[H4]   = Http4sTp.httpOps
+   override given ops: HttpOps[H4]              = Http4sTp.httpOps
    override given sigSuite: SigningSuiteHelpers = new SigningSuiteHelpers

--- a/http4s/jvm/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJVM.scala
+++ b/http4s/jvm/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuiteJVM.scala
@@ -19,8 +19,9 @@ package run.cosy.http4s.auth
 import run.cosy.http.HttpOps
 import run.cosy.http.auth.SigningSuiteHelpers
 import run.cosy.http4s.Http4sTp
+import run.cosy.http4s.Http4sTp.H4
 
-class Http4sMessageSigningSuiteJVM extends run.cosy.http4s.auth.Http4sMessageSigningSuite:
+class Http4sMessageSigningSuiteJVM[F[_]] extends run.cosy.http4s.auth.Http4sMessageSigningSuite[F]:
    given pem: bobcats.util.PEMUtils             = bobcats.util.BouncyJavaPEMUtils
-   override given ops: HttpOps[Http4sTp.type]   = Http4sTp.httpOps
+   override given ops: HttpOps[H4]   = Http4sTp.httpOps
    override given sigSuite: SigningSuiteHelpers = new SigningSuiteHelpers

--- a/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
@@ -22,32 +22,39 @@ import run.cosy.http.Http.{Header, Message}
 import run.cosy.http.{Http, HttpOps}
 
 object Http4sTp extends Http:
-   override type Message  = org.http4s.Request[?] | org.http4s.Response[?]
-   override type Request  = org.http4s.Request[?]
-   override type Response = org.http4s.Response[?]
+   override type Message  = [F[_]] =>> (org.http4s.Request[F] | org.http4s.Response[F])
+   override type Request  = [F[_]] =>> org.http4s.Request[F]
+   override type Response = [F[_]] =>> org.http4s.Response[F]
 
    override type Header = org.http4s.Header.Raw
 
-   given httpOps: HttpOps[Http4sTp.type] with
-      type H = Http4sTp.type
-      extension (msg: Http.Message[H])
-        def headers: Seq[Http.Header[H]] = msg.headers.headers
+   given httpOps: HttpOps[H4] with
+      
+      extension [F[_]](msg: Http.Message[F, H4])
+        def headers: Seq[Http.Header[H4]] =
+          //the asInstanceOf is needed here to avoid infinite recursion on `headers`
+          msg.asInstanceOf[org.http4s.Message[F]].headers.headers
 
-      extension [R <: Http.Message[H]](msg: R)
-         def addHeaders(headers: Seq[Http.Header[H]]): R =
-           msg.withHeaders(msg.headers ++ Headers(headers.toList))
-             .asInstanceOf[R] // todo: how to get same result without asInstanceOf?
+      extension [F[_], R <: Http.Message[F, H4]](msg: R)
+         def addHeaders(headers: Seq[Http.Header[H4]]): R =
+           val m = msg.asInstanceOf[org.http4s.Message[F]]
+           m.withHeaders((m.headers ++ Headers(headers)))
+             .asInstanceOf[R]
 
          def addHeader(name: String, value: String): R =
-           msg.putHeaders(org.http4s.Header.Raw(CIString(name), value))
+           val m = msg.asInstanceOf[org.http4s.Message[F]]
+           m.putHeaders(org.http4s.Header.Raw(CIString(name), value))
              .asInstanceOf[R]
          // this is used in tests
          def removeHeader(name: String): R =
-           msg.removeHeader(CIString(name))
+           val m = msg.asInstanceOf[org.http4s.Message[F]]
+           m.removeHeader(CIString(name))
              .asInstanceOf[R]
 
          // used in tests: return the Optional Value
          def headerValue(name: String): Option[String] =
-           msg.headers.get(CIString(name)).map { nel =>
+           val m = msg.asInstanceOf[org.http4s.Message[F]]
+           m.headers.get(CIString(name)).map { nel =>
              nel.foldLeft("")((str, raw) => str + ", " + raw.value.trim)
            }
+end Http4sTp

--- a/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
@@ -22,9 +22,9 @@ import run.cosy.http.Http.{Header, Message}
 import run.cosy.http.{Http, HttpOps}
 
 object Http4sTp extends Http:
-   override type Message  = [F[_]] =>> (org.http4s.Request[F] | org.http4s.Response[F])
-   override type Request  = [F[_]] =>> org.http4s.Request[F]
-   override type Response = [F[_]] =>> org.http4s.Response[F]
+   override type Message[F[_]]  =  org.http4s.Request[F] | org.http4s.Response[F]
+   override type Request[F[_]]  =  org.http4s.Request[F]
+   override type Response[F[_]] =  org.http4s.Response[F]
 
    override type Header = org.http4s.Header.Raw
 

--- a/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
@@ -22,9 +22,9 @@ import run.cosy.http.Http.{Header, Message}
 import run.cosy.http.{Http, HttpOps}
 
 object Http4sTp extends Http:
-   override type Message[F[_]]  =  org.http4s.Request[F] | org.http4s.Response[F]
-   override type Request[F[_]]  =  org.http4s.Request[F]
-   override type Response[F[_]] =  org.http4s.Response[F]
+   override type Message[F[_]]  = org.http4s.Request[F] | org.http4s.Response[F]
+   override type Request[F[_]]  = org.http4s.Request[F]
+   override type Response[F[_]] = org.http4s.Response[F]
 
    override type Header = org.http4s.Header.Raw
 

--- a/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
@@ -29,32 +29,32 @@ object Http4sTp extends Http:
    override type Header = org.http4s.Header.Raw
 
    given httpOps: HttpOps[H4] with
-      
+
       extension [F[_]](msg: Http.Message[F, H4])
         def headers: Seq[Http.Header[H4]] =
-          //the asInstanceOf is needed here to avoid infinite recursion on `headers`
+          // the asInstanceOf is needed here to avoid infinite recursion on `headers`
           msg.asInstanceOf[org.http4s.Message[F]].headers.headers
 
       extension [F[_], R <: Http.Message[F, H4]](msg: R)
          def addHeaders(headers: Seq[Http.Header[H4]]): R =
-           val m = msg.asInstanceOf[org.http4s.Message[F]]
-           m.withHeaders((m.headers ++ Headers(headers)))
-             .asInstanceOf[R]
+            val m = msg.asInstanceOf[org.http4s.Message[F]]
+            m.withHeaders((m.headers ++ Headers(headers)))
+              .asInstanceOf[R]
 
          def addHeader(name: String, value: String): R =
-           val m = msg.asInstanceOf[org.http4s.Message[F]]
-           m.putHeaders(org.http4s.Header.Raw(CIString(name), value))
-             .asInstanceOf[R]
+            val m = msg.asInstanceOf[org.http4s.Message[F]]
+            m.putHeaders(org.http4s.Header.Raw(CIString(name), value))
+              .asInstanceOf[R]
          // this is used in tests
          def removeHeader(name: String): R =
-           val m = msg.asInstanceOf[org.http4s.Message[F]]
-           m.removeHeader(CIString(name))
-             .asInstanceOf[R]
+            val m = msg.asInstanceOf[org.http4s.Message[F]]
+            m.removeHeader(CIString(name))
+              .asInstanceOf[R]
 
          // used in tests: return the Optional Value
          def headerValue(name: String): Option[String] =
-           val m = msg.asInstanceOf[org.http4s.Message[F]]
-           m.headers.get(CIString(name)).map { nel =>
-             nel.foldLeft("")((str, raw) => str + ", " + raw.value.trim)
-           }
+            val m = msg.asInstanceOf[org.http4s.Message[F]]
+            m.headers.get(CIString(name)).map { nel =>
+              nel.foldLeft("")((str, raw) => str + ", " + raw.value.trim)
+            }
 end Http4sTp

--- a/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/Http4sTp.scala
@@ -28,15 +28,15 @@ object Http4sTp extends Http:
 
    override type Header = org.http4s.Header.Raw
 
-   given httpOps: HttpOps[H4] with
+   given hOps: HttpOps[HT] with
 
-      extension [F[_]](msg: Http.Message[F, H4])
-        def headers: Seq[Http.Header[H4]] =
+      extension [F[_]](msg: Http.Message[F, HT])
+        def headers: Seq[Http.Header[HT]] =
           // the asInstanceOf is needed here to avoid infinite recursion on `headers`
           msg.asInstanceOf[org.http4s.Message[F]].headers.headers
 
-      extension [F[_], R <: Http.Message[F, H4]](msg: R)
-         def addHeaders(headers: Seq[Http.Header[H4]]): R =
+      extension [F[_], R <: Http.Message[F, HT]](msg: R)
+         def addHeaders(headers: Seq[Http.Header[HT]]): R =
             val m = msg.asInstanceOf[org.http4s.Message[F]]
             m.withHeaders((m.headers ++ Headers(headers)))
               .asInstanceOf[R]

--- a/http4s/shared/src/main/scala/run/cosy/http4s/auth/Http4sMessageSignature.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/auth/Http4sMessageSignature.scala
@@ -17,9 +17,9 @@
 package run.cosy.http4s.auth
 
 import run.cosy.http.auth.{SignatureInputMatcher, SignatureMatcher}
-import run.cosy.http4s.Http4sTp.H4
+import run.cosy.http4s.Http4sTp.HT as AH
 
-object Http4sMessageSignature extends run.cosy.http.auth.MessageSignature[H4]:
-   override protected val Signature: SignatureMatcher[H4] = run.cosy.http4s.headers.Signature
-   override protected val `Signature-Input`: SignatureInputMatcher[H4] =
+object Http4sMessageSignature extends run.cosy.http.auth.MessageSignature[AH]:
+   override protected val Signature: SignatureMatcher[AH] = run.cosy.http4s.headers.Signature
+   override protected val `Signature-Input`: SignatureInputMatcher[AH] =
      run.cosy.http4s.headers.`Signature-Input`

--- a/http4s/shared/src/main/scala/run/cosy/http4s/auth/Http4sMessageSignature.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/auth/Http4sMessageSignature.scala
@@ -17,10 +17,9 @@
 package run.cosy.http4s.auth
 
 import run.cosy.http.auth.{SignatureInputMatcher, SignatureMatcher}
-import run.cosy.http4s.Http4sTp
+import run.cosy.http4s.Http4sTp.H4
 
-object Http4sMessageSignature extends run.cosy.http.auth.MessageSignature[Http4sTp.type]:
-   type H = Http4sTp.type
-   override protected val Signature: SignatureMatcher[H] = run.cosy.http4s.headers.Signature
-   override protected val `Signature-Input`: SignatureInputMatcher[H] =
+object Http4sMessageSignature extends run.cosy.http.auth.MessageSignature[H4]:
+   override protected val Signature: SignatureMatcher[H4] = run.cosy.http4s.headers.Signature
+   override protected val `Signature-Input`: SignatureInputMatcher[H4] =
      run.cosy.http4s.headers.`Signature-Input`

--- a/http4s/shared/src/main/scala/run/cosy/http4s/headers/HeaderSelector.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/headers/HeaderSelector.scala
@@ -39,12 +39,12 @@ import run.cosy.http.auth.{
 }
 import run.cosy.http.headers.Rfc8941.SfDict
 import run.cosy.http.headers.Rfc8941.Serialise.given
-import run.cosy.http4s.Http4sTp.H4
-import org.http4s.{Request as H4Request, Message as H4Message, Response as H4Response}
+import run.cosy.http4s.Http4sTp.HT
+import org.http4s.{Request as HTRequest, Message as HTMessage, Response as HTResponse}
 
 import java.util.Locale
 
-trait BasicHeaderSelector[F[_], HM <: Http.Message[F, H4]]
+trait BasicHeaderSelector[F[_], HM <: Http.Message[F, HT]]
     extends BasicMessageSelector[HM] with Http4sHeaderSelector[F, HM]:
    def lowercaseHeaderName: String = lowercaseName
 
@@ -53,11 +53,11 @@ trait BasicHeaderSelector[F[_], HM <: Http.Message[F, H4]]
      yield SelectorOps.collate(headers)
 end BasicHeaderSelector
 
-trait Http4sHeaderSelector[F[_], HM <: Http.Message[F, H4]] extends HeaderSelector[HM]:
+trait Http4sHeaderSelector[F[_], HM <: Http.Message[F, HT]] extends HeaderSelector[HM]:
    lazy val ciLowercaseName: CIString = CIString(lowercaseHeaderName)
 
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
-      val m = msg.asInstanceOf[H4Message[F]]
+      val m = msg.asInstanceOf[HTMessage[F]]
       for
          nonEmpty <- m.headers.get(ciLowercaseName)
            .toRight(UnableToCreateSigHeaderException(
@@ -66,7 +66,7 @@ trait Http4sHeaderSelector[F[_], HM <: Http.Message[F, H4]] extends HeaderSelect
       yield nonEmpty.map(_.value)
 end Http4sHeaderSelector
 
-trait Http4sDictSelector[F[_], HM <: Http.Message[F, H4]]
+trait Http4sDictSelector[F[_], HM <: Http.Message[F, HT]]
     extends DictSelector[HM] with Http4sHeaderSelector[F, HM]:
    override lazy val lowercaseHeaderName: String = lowercaseName
 

--- a/http4s/shared/src/main/scala/run/cosy/http4s/headers/HeaderSelector.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/headers/HeaderSelector.scala
@@ -42,11 +42,10 @@ import run.cosy.http.headers.Rfc8941.Serialise.given
 import run.cosy.http4s.Http4sTp.H4
 import org.http4s.{Request as H4Request, Message as H4Message, Response as H4Response}
 
-
 import java.util.Locale
 
-trait BasicHeaderSelector[F[_], HM <: Http.Message[F,H4]]
-    extends BasicMessageSelector[HM] with Http4sHeaderSelector[F,HM]:
+trait BasicHeaderSelector[F[_], HM <: Http.Message[F, H4]]
+    extends BasicMessageSelector[HM] with Http4sHeaderSelector[F, HM]:
    def lowercaseHeaderName: String = lowercaseName
 
    override protected def signingStringValue(msg: HM): Try[String] =
@@ -56,15 +55,15 @@ end BasicHeaderSelector
 
 trait Http4sHeaderSelector[F[_], HM <: Http.Message[F, H4]] extends HeaderSelector[HM]:
    lazy val ciLowercaseName: CIString = CIString(lowercaseHeaderName)
-   
+
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
-     val m  = msg.asInstanceOf[H4Message[F]]
-     for
-        nonEmpty <- m.headers.get(ciLowercaseName)
-          .toRight(UnableToCreateSigHeaderException(
-            s"""No headers "$lowercaseHeaderName" in http message"""
-          )).toTry
-     yield nonEmpty.map(_.value)
+      val m = msg.asInstanceOf[H4Message[F]]
+      for
+         nonEmpty <- m.headers.get(ciLowercaseName)
+           .toRight(UnableToCreateSigHeaderException(
+             s"""No headers "$lowercaseHeaderName" in http message"""
+           )).toTry
+      yield nonEmpty.map(_.value)
 end Http4sHeaderSelector
 
 trait Http4sDictSelector[F[_], HM <: Http.Message[F, H4]]

--- a/http4s/shared/src/main/scala/run/cosy/http4s/headers/HeaderSelector.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/headers/HeaderSelector.scala
@@ -29,7 +29,7 @@ import run.cosy.http.headers.{
 }
 
 import scala.util.{Failure, Success, Try}
-import org.typelevel.ci.{CIString, *}
+import org.typelevel.ci.*
 import run.cosy.http.Http
 import run.cosy.http.auth.{
   AttributeMissingException,
@@ -39,12 +39,14 @@ import run.cosy.http.auth.{
 }
 import run.cosy.http.headers.Rfc8941.SfDict
 import run.cosy.http.headers.Rfc8941.Serialise.given
-import run.cosy.http4s.Http4sTp
+import run.cosy.http4s.Http4sTp.H4
+import org.http4s.{Request as H4Request, Message as H4Message, Response as H4Response}
+
 
 import java.util.Locale
 
-trait BasicHeaderSelector[HM <: Message[?]]
-    extends BasicMessageSelector[HM] with Http4sHeaderSelector[HM]:
+trait BasicHeaderSelector[F[_], HM <: Http.Message[F,H4]]
+    extends BasicMessageSelector[HM] with Http4sHeaderSelector[F,HM]:
    def lowercaseHeaderName: String = lowercaseName
 
    override protected def signingStringValue(msg: HM): Try[String] =
@@ -52,227 +54,21 @@ trait BasicHeaderSelector[HM <: Message[?]]
      yield SelectorOps.collate(headers)
 end BasicHeaderSelector
 
-trait Http4sHeaderSelector[HM <: Message[?]] extends HeaderSelector[HM]:
-   def lowercaseHeaderName: String
+trait Http4sHeaderSelector[F[_], HM <: Http.Message[F, H4]] extends HeaderSelector[HM]:
    lazy val ciLowercaseName: CIString = CIString(lowercaseHeaderName)
-
+   
    override def filterHeaders(msg: HM): Try[NonEmptyList[String]] =
+     val m  = msg.asInstanceOf[H4Message[F]]
      for
-        nonEmpty <- msg.headers.get(ciLowercaseName)
+        nonEmpty <- m.headers.get(ciLowercaseName)
           .toRight(UnableToCreateSigHeaderException(
             s"""No headers "$lowercaseHeaderName" in http message"""
           )).toTry
      yield nonEmpty.map(_.value)
 end Http4sHeaderSelector
 
-trait Http4sDictSelector[HM <: Http.Message[Http4sTp.type]]
-    extends DictSelector[HM] with Http4sHeaderSelector[HM]:
+trait Http4sDictSelector[F[_], HM <: Http.Message[F, H4]]
+    extends DictSelector[HM] with Http4sHeaderSelector[F, HM]:
    override lazy val lowercaseHeaderName: String = lowercaseName
 
 end Http4sDictSelector
-
-// the simple header selectors
-
-object authorization extends BasicHeaderSelector[Request[?]]:
-   override def lowercaseName: String = "authorization"
-
-object `cache-control` extends BasicHeaderSelector[Message[?]]:
-   override def lowercaseName: String = "cache-control"
-
-object date extends BasicHeaderSelector[Message[?]]:
-   override def lowercaseName: String = "date"
-
-object etag extends BasicHeaderSelector[Response[?]]:
-   override def lowercaseName: String = "etag"
-
-object host extends BasicHeaderSelector[Request[?]]:
-   override def lowercaseName: String = "host"
-
-object `content-type` extends BasicHeaderSelector[Message[?]]:
-   override def lowercaseName: String = "content-type"
-
-object `content-length` extends BasicHeaderSelector[Message[?]]:
-   override def lowercaseName: String = "content-length"
-
-object digest extends BasicHeaderSelector[Message[?]]:
-   override val lowercaseName: String = "digest"
-
-object signature extends Http4sDictSelector[Http.Message[Http4sTp.type]]:
-   override val lowercaseName: String = "signature"
-
-/** `@request-target` refers to the full request target of the HTTP request message, as defined in
-  * "HTTP Semantics" For HTTP 1.1, the component value is equivalent to the request target portion
-  * of the request line. However, this value is more difficult to reliably construct in other
-  * versions of HTTP. Therefore, it is NOT RECOMMENDED that this identifier be used when versions of
-  * HTTP other than 1.1 might be in use.
-  *
-  * @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-request-target
-  */
-object `@request-target` extends BasicMessageSelector[Request[?]]:
-   override def lowercaseName: String       = "@request-target"
-   override def specialForRequests: Boolean = true
-   // todo: return an error if http version above 1.1? (see spec warning)
-   override protected def signingStringValue(msg: Request[?]): Try[String] =
-     Try(msg.uri.renderString)
-end `@request-target`
-
-/*
- * can also be used in a response, but requires the original request to
- * calculate
- * @see https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-method
- */
-object `@method` extends BasicMessageSelector[Request[?]]:
-   override def lowercaseName: String       = "@method"
-   override def specialForRequests: Boolean = true
-
-   override protected def signingStringValue(msg: Request[?]): Try[String] =
-     Success(msg.method.name) // already uppercase
-end `@method`
-
-/** in order to give the target URI we need to know if this is an https connection and what the host
-  * header is if not specified in the request note: can also be used in a response, but requires the
-  * original request to calculate
-  *
-  * @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-target-uri
-  */
-import org.http4s.Uri
-case class `@target-uri`(securedConnection: Boolean, defaultAuthority: Uri.Authority)
-    extends BasicMessageSelector[Request[?]]:
-   val defaultScheme: Some[Uri.Scheme] =
-     if securedConnection then Some(Uri.Scheme.https) else Some(Uri.Scheme.http)
-   val defaultAuthorityOpt: Some[Uri.Authority] = Some(defaultAuthority)
-   override def lowercaseName: String           = "@target-uri"
-   override def specialForRequests: Boolean     = true
-
-   override protected def signingStringValue(msg: Request[?]): Try[String] =
-      val uri = msg.uri
-      if uri.scheme.isDefined && uri.authority.isDefined then Success(uri.renderString)
-      else
-         Success(uri.copy(
-           uri.scheme.orElse(defaultScheme),
-           uri.authority.orElse {
-             msg.headers.get[Host]
-               .map(h => Uri.Authority(None, Uri.RegName(h.host), h.port))
-               .orElse(defaultAuthorityOpt)
-           }
-         ).renderString)
-
-end `@target-uri`
-
-/** we may need to know the host name of the server to use as a default note: can also be used in a
-  * response, but requires the original request to calculate
-  *
-  * @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-authority
-  */
-case class `@authority`(defaultHostHeader: Uri.Authority) extends BasicMessageSelector[Request[?]]:
-   override def lowercaseName: String       = "@authority"
-   override def specialForRequests: Boolean = true
-
-   override protected def signingStringValue(msg: Request[?]): Try[String] =
-     Success(msg.uri.authority.getOrElse(
-       msg.headers.get[Host]
-         .map(h => Uri.Authority(None, Uri.RegName(h.host), h.port))
-         .getOrElse(defaultHostHeader)
-     ).renderString)
-
-end `@authority`
-
-/** we need to know if the server is running on http or https
-  *
-  * @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-scheme
-  */
-case class `@scheme`(secure: Boolean) extends BasicMessageSelector[Request[?]]:
-   override def lowercaseName: String       = "@scheme"
-   override def specialForRequests: Boolean = true
-   val scheme: Uri.Scheme                   = if secure then Uri.Scheme.https else Uri.Scheme.http
-
-   // todo: inefficient as it builds whole URI to extract only a small piece
-   override protected def signingStringValue(msg: Request[?]): Try[String] = Success(scheme.value)
-end `@scheme`
-
-/** @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-path
-  */
-object `@path` extends BasicMessageSelector[Request[?]]:
-   override def lowercaseName: String       = "@path"
-   override def specialForRequests: Boolean = true
-
-   override protected def signingStringValue(msg: Request[?]): Try[String] = Try(
-     msg.uri.path.renderString
-   )
-end `@path`
-
-/** @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-status-code
-  */
-object `@status` extends BasicMessageSelector[Response[?]]:
-   override def lowercaseName: String = "@status"
-
-   override protected def signingStringValue(msg: Response[?]): Try[String] =
-     Success("" + msg.status.code)
-end `@status`
-
-/** @see https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-query */
-object `@query` extends BasicMessageSelector[Request[?]]:
-   override def lowercaseName: String       = "@query"
-   override def specialForRequests: Boolean = true
-
-   override protected def signingStringValue(msg: Request[?]): Try[String] =
-      val q = msg.uri.query
-      Success {
-        if q == Query.empty then ""
-        else if q == Query.blank then "?"
-        else
-           val qs = msg.uri.query.renderString
-           if qs == "" then "?" else "?" + qs // todo: check this is right
-      }
-end `@query`
-
-/** @see
-  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#name-query-parameters
-  */
-object `@query-params` extends MessageSelector[Request[?]]:
-   val nameParam: Rfc8941.Token             = Rfc8941.Token("name")
-   override def lowercaseName: String       = "@query-params"
-   override def specialForRequests: Boolean = true
-
-   override def signingString(msg: Request[?], params: Rfc8941.Params): Try[String] =
-     params.toSeq match
-        case Seq(nameParam -> (value: Rfc8941.SfString)) => Try {
-            val queryStr = msg.uri.query.params.get(value.asciiStr).getOrElse("")
-            s""""$lowercaseName";name=${value.canon}: $queryStr"""
-          }
-        case _ => Failure(
-            SelectorException(
-              s"selector $lowercaseName only takes ${nameParam.canon} parameters. Received " + params
-            )
-          )
-end `@query-params`
-
-object `@request-response` extends MessageSelector[Request[?]]:
-   val keyParam: Rfc8941.Token              = Rfc8941.Token("key")
-   override def lowercaseName: String       = "@request-response"
-   override def specialForRequests: Boolean = true
-
-   override def signingString(msg: Request[?], params: Rfc8941.Params): Try[String] =
-     params.toSeq match
-        case Seq(keyParam -> (value: Rfc8941.SfString)) => signingStringFor(msg, value)
-        case _ => Failure(
-            SelectorException(
-              s"selector $lowercaseName only takes ${keyParam.canon} paramters. Received " + params
-            )
-          )
-
-   protected def signingStringFor(msg: Request[?], key: Rfc8941.SfString): Try[String] =
-     for
-        sigsDict <- signature.sfDictParse(msg)
-        keyStr   <- Try(Rfc8941.Token(key.asciiStr))
-        signature <- sigsDict.get(keyStr)
-          .toRight(AttributeMissingException(s"could not find signature '$keyStr'"))
-          .toTry
-     yield s""""$lowercaseName";key=${key.canon}: ${signature.canon}"""
-end `@request-response`

--- a/http4s/shared/src/main/scala/run/cosy/http4s/headers/Http4sMessageSelectors.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/headers/Http4sMessageSelectors.scala
@@ -22,16 +22,16 @@ import run.cosy.http.Http.*
 import run.cosy.http.headers.{DictSelector, HeaderSelector, MessageSelector, MessageSelectors}
 import run.cosy.http4s.Http4sTp.H4
 import run.cosy.http.headers.BasicMessageSelector
-import scala.util.{Try,Success,Failure}
+import scala.util.{Try, Success, Failure}
 import org.http4s.headers.Host
 import org.http4s.Query
 import run.cosy.http.headers.Rfc8941.Serialise.given
 import run.cosy.http.headers.Rfc8941
-import run.cosy.http.auth.{AttributeMissingException,SelectorException}
+import run.cosy.http.auth.{AttributeMissingException, SelectorException}
 
 object Http4sMessageSelector:
    def request[F[_]](name: String): MessageSelector[Http.Request[F, H4]] =
-     new BasicHeaderSelector[F,Http.Request[F, H4]]:
+     new BasicHeaderSelector[F, Http.Request[F, H4]]:
         override val lowercaseName: String = name
    def response[F[_]](name: String): MessageSelector[Http.Response[F, H4]] =
      new BasicHeaderSelector[F, Http.Response[F, H4]]:

--- a/http4s/shared/src/main/scala/run/cosy/http4s/headers/Http4sMessageSelectors.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/headers/Http4sMessageSelectors.scala
@@ -20,7 +20,7 @@ import org.http4s.{Uri, Message as H4Message, Request as H4Request, Response as 
 import run.cosy.http.Http
 import run.cosy.http.Http.*
 import run.cosy.http.headers.{DictSelector, HeaderSelector, MessageSelector, MessageSelectors}
-import run.cosy.http4s.Http4sTp.H4
+import run.cosy.http4s.Http4sTp.HT as H4
 import run.cosy.http.headers.BasicMessageSelector
 import scala.util.{Try, Success, Failure}
 import org.http4s.headers.Host

--- a/http4s/shared/src/main/scala/run/cosy/http4s/headers/Http4sMessageSelectors.scala
+++ b/http4s/shared/src/main/scala/run/cosy/http4s/headers/Http4sMessageSelectors.scala
@@ -16,71 +16,239 @@
 
 package run.cosy.http4s.headers
 
-import org.http4s.Uri
+import org.http4s.{Uri, Message as H4Message, Request as H4Request, Response as H4Response}
 import run.cosy.http.Http
-import run.cosy.http.Http.{Message, Request, Response}
+import run.cosy.http.Http.*
 import run.cosy.http.headers.{DictSelector, HeaderSelector, MessageSelector, MessageSelectors}
-import run.cosy.http4s.Http4sTp
+import run.cosy.http4s.Http4sTp.H4
+import run.cosy.http.headers.BasicMessageSelector
+import scala.util.{Try,Success,Failure}
+import org.http4s.headers.Host
+import org.http4s.Query
+import run.cosy.http.headers.Rfc8941.Serialise.given
+import run.cosy.http.headers.Rfc8941
+import run.cosy.http.auth.{AttributeMissingException,SelectorException}
 
 object Http4sMessageSelector:
-   type H = Http4sTp.type
-   def request(name: String): MessageSelector[Request[H]] =
-     new BasicHeaderSelector[Request[H]]:
+   def request[F[_]](name: String): MessageSelector[Http.Request[F, H4]] =
+     new BasicHeaderSelector[F,Http.Request[F, H4]]:
         override val lowercaseName: String = name
-   def response(name: String): MessageSelector[Response[H]] =
-     new BasicHeaderSelector[Response[H]]:
-        override val lowercaseName: String = name
-
-   def hdrMessage(name: String): MessageSelector[Message[H]] =
-     new BasicHeaderSelector[Message[H]]:
+   def response[F[_]](name: String): MessageSelector[Http.Response[F, H4]] =
+     new BasicHeaderSelector[F, Http.Response[F, H4]]:
         override val lowercaseName: String = name
 
-   def dictMsg(name: String): DictSelector[Message[H]] =
-     new Http4sDictSelector[Message[H]]:
-        override def lowercaseName: String = name
+//   def hdrMessage[F[_]](name: String): MessageSelector[Http.Message[F, H4]] =
+//     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+//        override val lowercaseName: String = name
+//
+//   def dictMsg[F[_], M <: Http.Message[F, H4]](name: String): DictSelector[M] =
+//     new Http4sDictSelector[F, M]:
+//        override def lowercaseName: String = name
 end Http4sMessageSelector
 
-class Http4sMessageSelectors(
+class Http4sMessageSelectors[F[_]](
     val securedConnection: Boolean,
-    val defaultHost: Uri.Authority,
+    val defaultAuthority: Uri.Authority,
     val defaultPort: Int
-) extends MessageSelectors[Http4sMessageSelector.H]:
+) extends MessageSelectors[F, H4]:
    import Http4sMessageSelector.*
 
-   override lazy val authorization: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.authorization
-   override lazy val date: MessageSelector[Message[H]]            = run.cosy.http4s.headers.date
-   override lazy val etag: MessageSelector[Response[H]]           = run.cosy.http4s.headers.etag
-   override lazy val host: MessageSelector[Request[H]]            = run.cosy.http4s.headers.host
-   override lazy val signature: DictSelector[Message[H]]          = dictMsg("signature")
-   override lazy val digest: MessageSelector[Message[H]]          = run.cosy.http4s.headers.digest
-   override lazy val forwarded: MessageSelector[Message[H]]       = hdrMessage("forwarded")
-   override lazy val `cache-control`: MessageSelector[Message[H]] = hdrMessage("cache-control")
-   override lazy val `client-cert`: MessageSelector[Message[H]]   = hdrMessage("client-cert")
-   override lazy val `content-length`: MessageSelector[Message[H]] =
-     run.cosy.http4s.headers.`content-length`
-   override lazy val `content-type`: MessageSelector[Message[H]] =
-     run.cosy.http4s.headers.`content-type`
+   override lazy val authorization: MessageSelector[Http.Request[F, H4]] =
+     new BasicHeaderSelector[F, Http.Request[F, H4]]:
+        override def lowercaseName: String = "authorization"
 
-   override lazy val `@request-target`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@request-target`
-   override lazy val `@method`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@method`
-   override lazy val `@target-uri`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@target-uri`(securedConnection, defaultHost)
-   override lazy val `@authority`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@authority`(defaultHost)
-   override lazy val `@scheme`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@scheme`(securedConnection)
-   override lazy val `@path`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@path`
-   override lazy val `@status`: MessageSelector[Response[H]] =
-     run.cosy.http4s.headers.`@status`
-   override lazy val `@query`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@query`
-   override lazy val `@query-params`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@query-params`
-   override lazy val `@request-response`: MessageSelector[Request[H]] =
-     run.cosy.http4s.headers.`@request-response`
+   override lazy val date: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "date"
+
+   override lazy val etag: MessageSelector[Http.Response[F, H4]] =
+     new BasicHeaderSelector[F, Http.Response[F, H4]]:
+        override def lowercaseName: String = "etag"
+
+   override lazy val host: MessageSelector[Http.Request[F, H4]] =
+     new BasicHeaderSelector[F, Http.Request[F, H4]]:
+        override def lowercaseName: String = "host"
+
+   override lazy val signature: DictSelector[Http.Message[F, H4]] =
+     new Http4sDictSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "signature"
+
+   override lazy val digest: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "digest"
+
+   override lazy val forwarded: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "forwarded"
+
+   override lazy val `cache-control`: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "cache-control"
+
+   override lazy val `client-cert`: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "client-cert"
+
+   override lazy val `content-length`: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "content-length"
+
+   override lazy val `content-type`: MessageSelector[Http.Message[F, H4]] =
+     new BasicHeaderSelector[F, Http.Message[F, H4]]:
+        override def lowercaseName: String = "content-type"
+
+   override lazy val `@request-target`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        override def lowercaseName: String       = "@request-target"
+        override def specialForRequests: Boolean = true
+        // todo: return an error if http version above 1.1? (see spec warning)
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+           val m = msg.asInstanceOf[H4Request[F]]
+           Try(m.uri.renderString)
+   end `@request-target`
+
+   override lazy val `@method`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        override def lowercaseName: String       = "@method"
+        override def specialForRequests: Boolean = true
+
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+           val m = msg.asInstanceOf[H4Request[F]]
+           Success(m.method.name) // already uppercase
+   end `@method`
+
+   override lazy val `@target-uri`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        val defaultScheme: Some[Uri.Scheme] =
+          if securedConnection then Some(Uri.Scheme.https) else Some(Uri.Scheme.http)
+        val defaultAuthorityOpt: Some[Uri.Authority] = Some(defaultAuthority)
+        override def lowercaseName: String           = "@target-uri"
+        override def specialForRequests: Boolean     = true
+
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+           val m   = msg.asInstanceOf[H4Request[?]]
+           val uri = m.uri
+           if uri.scheme.isDefined && uri.authority.isDefined then Success(uri.renderString)
+           else
+              Success(uri.copy(
+                uri.scheme.orElse(defaultScheme),
+                uri.authority.orElse {
+                  m.headers.get[Host]
+                    .map(h => Uri.Authority(None, Uri.RegName(h.host), h.port))
+                    .orElse(defaultAuthorityOpt)
+                }
+              ).renderString)
+
+   end `@target-uri`
+
+   override lazy val `@authority`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        override def lowercaseName: String       = "@authority"
+        override def specialForRequests: Boolean = true
+
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+           val m = msg.asInstanceOf[H4Request[?]]
+           Success(m.uri.authority.getOrElse(
+             m.headers.get[Host]
+               .map(h => Uri.Authority(None, Uri.RegName(h.host), h.port))
+               .getOrElse(defaultAuthority)
+           ).renderString)
+
+   end `@authority`
+
+   override lazy val `@scheme`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        override def lowercaseName: String       = "@scheme"
+        override def specialForRequests: Boolean = true
+        val scheme: Uri.Scheme = if securedConnection then Uri.Scheme.https else Uri.Scheme.http
+
+        // todo: inefficient as it builds whole URI to extract only a small piece
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+          Success(scheme.value)
+   end `@scheme`
+
+   override lazy val `@path`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        override def lowercaseName: String       = "@path"
+        override def specialForRequests: Boolean = true
+
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+           val m = msg.asInstanceOf[H4Request[?]]
+           Try(m.uri.path.renderString)
+   end `@path`
+
+   override lazy val `@status`: MessageSelector[Http.Response[F, H4]] =
+     new BasicMessageSelector[Http.Response[F, H4]]:
+        override def lowercaseName: String = "@status"
+
+        override protected def signingStringValue(msg: Http.Response[F, H4]): Try[String] =
+           val m = msg.asInstanceOf[H4Response[F]]
+           Success("" + m.status.code)
+   end `@status`
+
+   override lazy val `@query`: MessageSelector[Http.Request[F, H4]] =
+     new BasicMessageSelector[Http.Request[F, H4]]:
+        override def lowercaseName: String       = "@query"
+        override def specialForRequests: Boolean = true
+
+        override protected def signingStringValue(msg: Http.Request[F, H4]): Try[String] =
+           val m = msg.asInstanceOf[H4Request[?]]
+           val q = m.uri.query
+           Success {
+             if q == Query.empty then ""
+             else if q == Query.blank then "?"
+             else
+                val qs = m.uri.query.renderString
+                if qs == "" then "?" else "?" + qs // todo: check this is right
+           }
+   end `@query`
+
+   override lazy val `@query-params`: MessageSelector[Http.Request[F, H4]] =
+     new MessageSelector[Http.Request[F, H4]]:
+        val nameParam: Rfc8941.Token             = Rfc8941.Token("name")
+        override def lowercaseName: String       = "@query-params"
+        override def specialForRequests: Boolean = true
+
+        override def signingString(msg: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
+           val m = msg.asInstanceOf[H4Request[?]]
+           params.toSeq match
+              case Seq(nameParam -> (value: Rfc8941.SfString)) => Try {
+                  val queryStr = m.uri.query.params.get(value.asciiStr).getOrElse("")
+                  s""""$lowercaseName";name=${value.canon}: $queryStr"""
+                }
+              case _ => Failure(
+                  SelectorException(
+                    s"selector $lowercaseName only takes ${nameParam.canon} parameters. Received " + params
+                  )
+                )
+   end `@query-params`
+
+   override lazy val `@request-response`: MessageSelector[Http.Request[F, H4]] =
+     new MessageSelector[Http.Request[F, H4]]:
+        val keyParam: Rfc8941.Token              = Rfc8941.Token("key")
+        override def lowercaseName: String       = "@request-response"
+        override def specialForRequests: Boolean = true
+
+        override def signingString(msg: Http.Request[F, H4], params: Rfc8941.Params): Try[String] =
+          params.toSeq match
+             case Seq(keyParam -> (value: Rfc8941.SfString)) => signingStringFor(msg, value)
+             case _ => Failure(
+                 SelectorException(
+                   s"selector $lowercaseName only takes ${keyParam.canon} paramters. Received " + params
+                 )
+               )
+
+        protected def signingStringFor(
+            msg: Http.Request[F, H4],
+            key: Rfc8941.SfString
+        ): Try[String] =
+          for
+             sigsDict <- signature.sfDictParse(msg)
+             keyStr   <- Try(Rfc8941.Token(key.asciiStr))
+             signature <- sigsDict.get(keyStr)
+               .toRight(AttributeMissingException(s"could not find signature '$keyStr'"))
+               .toTry
+          yield s""""$lowercaseName";key=${key.canon}: ${signature.canon}"""
+   end `@request-response`
 
 end Http4sMessageSelectors

--- a/http4s/shared/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuite.scala
+++ b/http4s/shared/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuite.scala
@@ -25,7 +25,7 @@ import org.typelevel.ci.CIString
 import run.cosy.http.Http
 import run.cosy.http4s.headers.{BasicHeaderSelector, Http4sDictSelector, Http4sMessageSelectors}
 import run.cosy.http.headers.MessageSelector
-import run.cosy.http4s.Http4sTp.H4
+import run.cosy.http4s.Http4sTp.HT as H4
 
 trait Http4sMessageSigningSuite[F[_]] extends HttpMessageSigningSuite[F, H4]:
    override val selectorsSecure: MessageSelectors[F, H4] =

--- a/http4s/shared/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuite.scala
+++ b/http4s/shared/src/test/scala/run/cosy/http4s/auth/Http4sMessageSigningSuite.scala
@@ -28,7 +28,7 @@ import run.cosy.http.headers.MessageSelector
 import run.cosy.http4s.Http4sTp.H4
 
 trait Http4sMessageSigningSuite[F[_]] extends HttpMessageSigningSuite[F, H4]:
-   override val selectorsSecure: MessageSelectors[F,H4] =
+   override val selectorsSecure: MessageSelectors[F, H4] =
      new Http4sMessageSelectors(true, Uri.Authority(None, Uri.RegName("bblfish.net"), None), 443)
    override val selectorsInSecure: MessageSelectors[F, H4] =
      new Http4sMessageSelectors(false, Uri.Authority(None, Uri.RegName("bblfish.net"), None), 80)
@@ -46,7 +46,7 @@ trait Http4sMessageSigningSuite[F[_]] extends HttpMessageSigningSuite[F, H4]:
                import org.http4s.Header.ToRaw.{given, *}
                // we can ignore the body here, since that is actually not relevant to signing
                org.http4s.Request[F](m, p, v, org.http4s.Headers(rawH))
-                 .asInstanceOf[Http.Request[F,H4]] //<- todo: why needed?
+                 .asInstanceOf[Http.Request[F, H4]] // <- todo: why needed?
              case _ => throw new Exception("Badly formed HTTP Request Command '" + head + "'")
         case _ => throw new Exception("Badly formed HTTP request")
 
@@ -61,7 +61,7 @@ trait Http4sMessageSigningSuite[F[_]] extends HttpMessageSigningSuite[F, H4]:
                val rawH: scala.List[org.http4s.Header.Raw] = parseHeaders(tail)
                import org.http4s.Header.ToRaw.{given, *}
                org.http4s.Response[F](status, version, org.http4s.Headers(rawH))
-                 .asInstanceOf[Http.Response[F,H4]] //<- todo: why needed?
+                 .asInstanceOf[Http.Response[F, H4]] // <- todo: why needed?
              case _ => throw new Exception("Badly formed HTTP Response Command '" + head + "'")
         case _ => throw new Exception("Badly formed HTTP request")
 

--- a/ietfSig/shared/src/main/scala/run/cosy/http/Http.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/Http.scala
@@ -19,12 +19,14 @@ package run.cosy.http
 import run.cosy.http.Http.Header
 
 trait Http:
-   rdf =>
-   type H4 = rdf.type
+   http =>
+   type HT = http.type
    type Message[F[_]] <: Matchable
    type Request[F[_]] <: Message[F]
    type Response[F[_]] <: Message[F]
    type Header <: Matchable
+   
+   given hOps: HttpOps[HT]
 end Http
 
 trait HttpOps[H <: Http]:

--- a/ietfSig/shared/src/main/scala/run/cosy/http/Http.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/Http.scala
@@ -37,7 +37,7 @@ trait HttpOps[H <: Http]:
    extension [F[_], R <: Http.Message[F, H]](msg: R)
       def addHeaders(headers: Seq[Http.Header[H]]): R
       // here we do really add a header to existing ones.
-      // note http4s 
+      // note http4s
       def addHeader(name: String, value: String): R
       // this is used in tests
       def removeHeader(name: String): R
@@ -46,13 +46,13 @@ trait HttpOps[H <: Http]:
 end HttpOps
 
 object Http:
-   type Message[F[_], H <: Http] =  Request[F, H] | Response[F, H]
+   type Message[F[_], H <: Http] = Request[F, H] | Response[F, H]
 
-   type Request[F[_], H <: Http]  =
+   type Request[F[_], H <: Http] =
      H match
         case GetRequest[F, req] => req
 
-   type Response[F[_], H <: Http]  =
+   type Response[F[_], H <: Http] =
      H match
         case GetResponse[F, res] => res
 

--- a/ietfSig/shared/src/main/scala/run/cosy/http/Http.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/Http.scala
@@ -25,7 +25,7 @@ trait Http:
    type Request[F[_]] <: Message[F]
    type Response[F[_]] <: Message[F]
    type Header <: Matchable
-   
+
    given hOps: HttpOps[HT]
 end Http
 

--- a/ietfSig/shared/src/main/scala/run/cosy/http/auth/MessageSignature.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/auth/MessageSignature.scala
@@ -64,14 +64,13 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
    protected val `Signature-Input`: SignatureInputMatcher[H]
 
    /** [[https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-03#section-4.1 Message Signatures]]
-     * Note: the F[_] here is playing too many roles. In http4s it is the type of the content itself, though in Akka that
-     *  is ignored. The other role of F is as a type of wrapper to fetch remote objects.
-     *  This is ok, as for our uses we don't ever look at the content of either messages, only at the headers.
-     *  (but for http4s we do need to know the type of the content or else we cannot correctly type the result of
-     *   adding headers to a Message)
+     * Note: the F[_] here is playing too many roles. In http4s it is the type of the content
+     * itself, though in Akka that is ignored. The other role of F is as a type of wrapper to fetch
+     * remote objects. This is ok, as for our uses we don't ever look at the content of either
+     * messages, only at the headers. (but for http4s we do need to know the type of the content or
+     * else we cannot correctly type the result of adding headers to a Message)
      */
-   extension [F[_], R <: Http.Message[F, H]](msg: R)(using
-     selectorDB: SelectorOps[R])
+   extension [F[_], R <: Http.Message[F, H]](msg: R)(using selectorDB: SelectorOps[R])
 
       /** Generate a function to create a new HttpRequest with the given Signature-Input header.
         * Called by the client, building the message.
@@ -191,8 +190,8 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
       def signatureAuthN[A](
           fetchKeyId: Rfc8941.SfString => F[SignatureVerifier[F, A]]
       )(using
-        ME: MonadError[F, Throwable],
-        clock : Clock[F]
+          ME: MonadError[F, Throwable],
+          clock: Clock[F]
       ): HttpSig => F[A] = (httpSig) =>
         for
            (si: SigInput, sig: Bytes) <- ME.fromTry(msg.getSignature(httpSig.proofName)

--- a/ietfSig/shared/src/main/scala/run/cosy/http/auth/MessageSignature.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/auth/MessageSignature.scala
@@ -64,8 +64,14 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
    protected val `Signature-Input`: SignatureInputMatcher[H]
 
    /** [[https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-03#section-4.1 Message Signatures]]
+     * Note: the F[_] here is playing too many roles. In http4s it is the type of the content itself, though in Akka that
+     *  is ignored. The other role of F is as a type of wrapper to fetch remote objects.
+     *  This is ok, as for our uses we don't ever look at the content of either messages, only at the headers.
+     *  (but for http4s we do need to know the type of the content or else we cannot correctly type the result of
+     *   adding headers to a Message)
      */
-   extension [R <: Message[H]](msg: R)(using selectorDB: SelectorOps[R])
+   extension [F[_], R <: Http.Message[F, H]](msg: R)(using
+     selectorDB: SelectorOps[R])
 
       /** Generate a function to create a new HttpRequest with the given Signature-Input header.
         * Called by the client, building the message.
@@ -80,13 +86,13 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
         *   can capture an IllegalArgumentException if the required headers are not present in the
         *   request
         */
-      def withSigInput[F[_]](
+      def withSigInput(
           name: Rfc8941.Token,
           sigInput: SigInput,
           signerF: SigningF[F]
       )(using meF: MonadError[F, Throwable]): F[R] =
         for
-           toSignBytes <- meF.fromTry(signingString(sigInput))
+           toSignBytes <- meF.fromTry(signingStr(sigInput))
            signature   <- signerF(toSignBytes)
         yield msg.addHeaders(Seq(
           `Signature-Input`(name, sigInput),
@@ -108,7 +114,7 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
         *   to be added to the Request. In the latter case use the withSigInput method. todo: it may
         *   be more correct if the result is a byte array, rather than a Unicode String.
         */
-      def signingString(sigInput: SigInput): Try[SigningString] =
+      def signingStr(sigInput: SigInput): Try[SigningString] =
          import Rfc8941.Serialise.{*, given}
 
          @tailrec
@@ -128,7 +134,7 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
 
          buildSigString(sigInput.headerItems.appended(`@signature-params`.pitem), "")
            .flatMap(string => ByteVector.encodeAscii(string).toTry)
-      end signingString
+      end signingStr
 
       /** get the signature data for a given signature name eg `sig1` from the headers.
         *
@@ -182,10 +188,11 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
         *   1. use `fetchKeyId` to construct the needed verifier
         *   1. Verify the header, and if verified return the Agent object A
         */
-      def signatureAuthN[F[_]: Clock, A](
+      def signatureAuthN[A](
           fetchKeyId: Rfc8941.SfString => F[SignatureVerifier[F, A]]
       )(using
-          ME: MonadError[F, Throwable]
+        ME: MonadError[F, Throwable],
+        clock : Clock[F]
       ): HttpSig => F[A] = (httpSig) =>
         for
            (si: SigInput, sig: Bytes) <- ME.fromTry(msg.getSignature(httpSig.proofName)
@@ -195,7 +202,7 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
            now <- summon[Clock[F]].realTime
            sigStr <-
              if si.isValidAt(now)
-             then ME.fromTry(msg.signingString(si))
+             then ME.fromTry(msg.signingStr(si))
              else
                 ME.fromTry(
                   Failure(new Throwable(s"Signature no longer valid at $now"))
@@ -206,12 +213,12 @@ trait MessageSignature[H <: Http](using ops: HttpOps[H]):
         yield agent
 
    /* needed for request-response dependencies */
-   extension (response: Response[H])(using
-       requestSelDB: SelectorOps[Request[H]],
-       responseSelDB: SelectorOps[Response[H]]
+   extension [F[_]](response: Response[F, H])(using
+       requestSelDB: SelectorOps[Request[F, H]],
+       responseSelDB: SelectorOps[Response[F, H]]
    )
 
-      def signingString(sigInput: SigInput, request: Request[H]): Try[SigningString] =
+      def signingString(sigInput: SigInput, request: Request[F, H]): Try[SigningString] =
          import Rfc8941.Serialise.{*, given}
 
          @tailrec

--- a/ietfSig/shared/src/main/scala/run/cosy/http/headers/MessageSelectors.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/headers/MessageSelectors.scala
@@ -20,39 +20,39 @@ import run.cosy.http.Http
 import run.cosy.http.headers.MessageSelector
 
 // implementations will need to specify default hosts and ports
-trait MessageSelectors[H <: Http]:
+trait MessageSelectors[F[_], H <: Http]:
    import Http.*
    val securedConnection: Boolean
 
-   lazy val authorization: MessageSelector[Request[H]]
-   lazy val `cache-control`: MessageSelector[Message[H]]
-   lazy val date: MessageSelector[Message[H]]
+   lazy val authorization: MessageSelector[Request[F,H]]
+   lazy val `cache-control`: MessageSelector[Message[F,H]]
+   lazy val date: MessageSelector[Message[F,H]]
 
-   lazy val etag: MessageSelector[Response[H]]
-   lazy val host: MessageSelector[Request[H]]
-   lazy val signature: DictSelector[Message[H]]
+   lazy val etag: MessageSelector[Response[F,H]]
+   lazy val host: MessageSelector[Request[F,H]]
+   lazy val signature: DictSelector[Message[F,H]]
 
-   lazy val `content-type`: MessageSelector[Message[H]]
-   lazy val `content-length`: MessageSelector[Message[H]]
-   lazy val digest: MessageSelector[Message[H]]
-   lazy val forwarded: MessageSelector[Message[H]]
-   lazy val `client-cert`: MessageSelector[Message[H]]
+   lazy val `content-type`: MessageSelector[Message[F,H]]
+   lazy val `content-length`: MessageSelector[Message[F,H]]
+   lazy val digest: MessageSelector[Message[F,H]]
+   lazy val forwarded: MessageSelector[Message[F,H]]
+   lazy val `client-cert`: MessageSelector[Message[F,H]]
 
-   lazy val `@request-target`: MessageSelector[Request[H]]
-   lazy val `@method`: MessageSelector[Request[H]]
-   lazy val `@target-uri`: MessageSelector[Request[H]]
-   lazy val `@authority`: MessageSelector[Request[H]]
-   lazy val `@scheme`: MessageSelector[Request[H]]
-   lazy val `@path`: MessageSelector[Request[H]]
-   lazy val `@status`: MessageSelector[Response[H]]
-   lazy val `@query`: MessageSelector[Request[H]]
-   lazy val `@query-params`: MessageSelector[Request[H]]
-   lazy val `@request-response`: MessageSelector[Request[H]]
+   lazy val `@request-target`: MessageSelector[Request[F,H]]
+   lazy val `@method`: MessageSelector[Request[F,H]]
+   lazy val `@target-uri`: MessageSelector[Request[F,H]]
+   lazy val `@authority`: MessageSelector[Request[F,H]]
+   lazy val `@scheme`: MessageSelector[Request[F,H]]
+   lazy val `@path`: MessageSelector[Request[F,H]]
+   lazy val `@status`: MessageSelector[Response[F,H]]
+   lazy val `@query`: MessageSelector[Request[F,H]]
+   lazy val `@query-params`: MessageSelector[Request[F,H]]
+   lazy val `@request-response`: MessageSelector[Request[F,H]]
 
    /** Note: @target-uri and @scheme can only be set by application code as a choice needs to be
      * made
      */
-   given requestSelectorOps: SelectorOps[Request[H]] = SelectorOps[Request[H]](
+   given requestSelectorOps: SelectorOps[Request[F,H]] = SelectorOps[Request[F,H]](
      authorization,
      host,
      forwarded,
@@ -75,8 +75,8 @@ trait MessageSelectors[H <: Http]:
 
    // both: digest, `content-length`, `content-type`, signature, date, `cache-control`
 
-   given responseSelectorOps: SelectorOps[Response[H]] =
-     SelectorOps[Response[H]](
+   given responseSelectorOps: SelectorOps[Response[F,H]] =
+     SelectorOps[Response[F,H]](
        `@status`,
        etag,
        // all these are good for requests too
@@ -87,3 +87,5 @@ trait MessageSelectors[H <: Http]:
        date,
        `cache-control`
      )
+
+end MessageSelectors

--- a/ietfSig/shared/src/main/scala/run/cosy/http/headers/MessageSelectors.scala
+++ b/ietfSig/shared/src/main/scala/run/cosy/http/headers/MessageSelectors.scala
@@ -24,35 +24,35 @@ trait MessageSelectors[F[_], H <: Http]:
    import Http.*
    val securedConnection: Boolean
 
-   lazy val authorization: MessageSelector[Request[F,H]]
-   lazy val `cache-control`: MessageSelector[Message[F,H]]
-   lazy val date: MessageSelector[Message[F,H]]
+   lazy val authorization: MessageSelector[Request[F, H]]
+   lazy val `cache-control`: MessageSelector[Message[F, H]]
+   lazy val date: MessageSelector[Message[F, H]]
 
-   lazy val etag: MessageSelector[Response[F,H]]
-   lazy val host: MessageSelector[Request[F,H]]
-   lazy val signature: DictSelector[Message[F,H]]
+   lazy val etag: MessageSelector[Response[F, H]]
+   lazy val host: MessageSelector[Request[F, H]]
+   lazy val signature: DictSelector[Message[F, H]]
 
-   lazy val `content-type`: MessageSelector[Message[F,H]]
-   lazy val `content-length`: MessageSelector[Message[F,H]]
-   lazy val digest: MessageSelector[Message[F,H]]
-   lazy val forwarded: MessageSelector[Message[F,H]]
-   lazy val `client-cert`: MessageSelector[Message[F,H]]
+   lazy val `content-type`: MessageSelector[Message[F, H]]
+   lazy val `content-length`: MessageSelector[Message[F, H]]
+   lazy val digest: MessageSelector[Message[F, H]]
+   lazy val forwarded: MessageSelector[Message[F, H]]
+   lazy val `client-cert`: MessageSelector[Message[F, H]]
 
-   lazy val `@request-target`: MessageSelector[Request[F,H]]
-   lazy val `@method`: MessageSelector[Request[F,H]]
-   lazy val `@target-uri`: MessageSelector[Request[F,H]]
-   lazy val `@authority`: MessageSelector[Request[F,H]]
-   lazy val `@scheme`: MessageSelector[Request[F,H]]
-   lazy val `@path`: MessageSelector[Request[F,H]]
-   lazy val `@status`: MessageSelector[Response[F,H]]
-   lazy val `@query`: MessageSelector[Request[F,H]]
-   lazy val `@query-params`: MessageSelector[Request[F,H]]
-   lazy val `@request-response`: MessageSelector[Request[F,H]]
+   lazy val `@request-target`: MessageSelector[Request[F, H]]
+   lazy val `@method`: MessageSelector[Request[F, H]]
+   lazy val `@target-uri`: MessageSelector[Request[F, H]]
+   lazy val `@authority`: MessageSelector[Request[F, H]]
+   lazy val `@scheme`: MessageSelector[Request[F, H]]
+   lazy val `@path`: MessageSelector[Request[F, H]]
+   lazy val `@status`: MessageSelector[Response[F, H]]
+   lazy val `@query`: MessageSelector[Request[F, H]]
+   lazy val `@query-params`: MessageSelector[Request[F, H]]
+   lazy val `@request-response`: MessageSelector[Request[F, H]]
 
    /** Note: @target-uri and @scheme can only be set by application code as a choice needs to be
      * made
      */
-   given requestSelectorOps: SelectorOps[Request[F,H]] = SelectorOps[Request[F,H]](
+   given requestSelectorOps: SelectorOps[Request[F, H]] = SelectorOps[Request[F, H]](
      authorization,
      host,
      forwarded,
@@ -75,8 +75,8 @@ trait MessageSelectors[F[_], H <: Http]:
 
    // both: digest, `content-length`, `content-type`, signature, date, `cache-control`
 
-   given responseSelectorOps: SelectorOps[Response[F,H]] =
-     SelectorOps[Response[F,H]](
+   given responseSelectorOps: SelectorOps[Response[F, H]] =
+     SelectorOps[Response[F, H]](
        `@status`,
        etag,
        // all these are good for requests too

--- a/ietfSigTests/shared/src/main/scala/run/cosy/http/auth/HttpMessageSigningSuite.scala
+++ b/ietfSigTests/shared/src/main/scala/run/cosy/http/auth/HttpMessageSigningSuite.scala
@@ -19,14 +19,16 @@ package run.cosy.http.auth
 import bobcats.AsymmetricKeyAlg.Signature
 import bobcats.PKCS8KeySpec
 import cats.effect.Async
-import run.cosy.http.{Http, HttpOps}
+import _root_.run.cosy.http.{Http, HttpOps}
 //todo: SignatureBytes is less likely to class with objects like Signature
 import bobcats.Verifier.{SigningString, Signature as SignatureBytes}
 import bobcats.{AsymmetricKeyAlg, SPKIKeySpec, SigningHttpMessages}
-import run.cosy.http.headers.*
-import run.cosy.http.headers.Rfc8941.*
-import run.cosy.http.headers.Rfc8941.SyntaxHelper.*
-import run.cosy.http.utils.StringUtils.*
+import _root_.run.cosy.http.headers.*
+import _root_.run.cosy.http.headers.Rfc8941.*
+import _root_.run.cosy.http.headers.Rfc8941.SyntaxHelper.*
+import _root_.run.cosy.http.utils.StringUtils.*
+import _root_.run.cosy.http.auth.MessageSignature
+import _root_.run.cosy.http.headers.SelectorOps
 import scodec.bits.ByteVector
 
 import cats.syntax.all.*
@@ -38,8 +40,8 @@ import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.security.{KeyFactory, MessageDigest, Signature as JSignature}
 import java.time.Clock
 import java.util.Base64
-import scala.language.implicitConversions
-import scala.util.{Failure, Success, Try}
+import _root_.scala.language.implicitConversions
+import _root_.scala.util.{Failure, Success, Try}
 
 trait HttpMessageSigningSuite[F[_], H <: Http] extends CatsEffectSuite:
 
@@ -51,7 +53,7 @@ trait HttpMessageSigningSuite[F[_], H <: Http] extends CatsEffectSuite:
    type HttpMessage = String
    val selectorsSecure: MessageSelectors[F, H]
    val selectorsInSecure: MessageSelectors[F, H]
-   val messageSignature: run.cosy.http.auth.MessageSignature[H]
+   val messageSignature: MessageSignature[H]
    
    import messageSignature.{*, given}
    import selectorsSecure.*
@@ -73,7 +75,7 @@ trait HttpMessageSigningSuite[F[_], H <: Http] extends CatsEffectSuite:
    def `request-target`(value: String): Success[String] = expectedHeader("@request-target", value)
    def expectedHeader(name: String, value: String)      = Success("\"" + name + "\": " + value)
 
-   given specialRequestSelectorOps: run.cosy.http.headers.SelectorOps[Request[F, H]] =
+   given specialRequestSelectorOps: SelectorOps[Request[F, H]] =
      selectorsSecure.requestSelectorOps.append(
        `x-example`,
        `x-empty-header`,
@@ -81,7 +83,7 @@ trait HttpMessageSigningSuite[F[_], H <: Http] extends CatsEffectSuite:
        `x-obs-fold-header`,
        `x-dictionary`
      )
-   given specialResponseSelectorOps: run.cosy.http.headers.SelectorOps[Response[F, H]] =
+   given specialResponseSelectorOps: SelectorOps[Response[F, H]] =
      selectorsSecure.responseSelectorOps.append(`x-dictionary`)
 
    @throws[Exception]

--- a/ietfSigTests/shared/src/main/scala/run/cosy/http/auth/HttpMessageSigningSuite.scala
+++ b/ietfSigTests/shared/src/main/scala/run/cosy/http/auth/HttpMessageSigningSuite.scala
@@ -23,24 +23,25 @@ import run.cosy.http.{Http, HttpOps}
 //todo: SignatureBytes is less likely to class with objects like Signature
 import bobcats.Verifier.{SigningString, Signature as SignatureBytes}
 import bobcats.{AsymmetricKeyAlg, SPKIKeySpec, SigningHttpMessages}
-import munit.CatsEffectSuite
 import run.cosy.http.headers.*
 import run.cosy.http.headers.Rfc8941.*
 import run.cosy.http.headers.Rfc8941.SyntaxHelper.*
-import scodec.bits.ByteVector
-import cats.effect.IO
 import run.cosy.http.utils.StringUtils.*
+import scodec.bits.ByteVector
+
+import cats.syntax.all.*
+import munit.CatsEffectSuite
+import cats.effect.{IO, SyncIO}
 
 import java.nio.charset.StandardCharsets
 import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.security.{KeyFactory, MessageDigest, Signature as JSignature}
 import java.time.Clock
 import java.util.Base64
-import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
-trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
+trait HttpMessageSigningSuite[F[_], H <: Http] extends CatsEffectSuite:
 
    given ops: HttpOps[H]
    given sigSuite: SigningSuiteHelpers
@@ -48,20 +49,20 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
    import Http.*
 
    type HttpMessage = String
-   val selectorsSecure: MessageSelectors[H]
-   val selectorsInSecure: MessageSelectors[H]
+   val selectorsSecure: MessageSelectors[F, H]
+   val selectorsInSecure: MessageSelectors[F, H]
    val messageSignature: run.cosy.http.auth.MessageSignature[H]
-
+   
    import messageSignature.{*, given}
    import selectorsSecure.*
    // special headers used in the spec that we won't find elsewhere
-   val `x-example`: MessageSelector[Request[H]]
-   val `x-empty-header`: MessageSelector[Request[H]]
-   val `x-ows-header`: MessageSelector[Request[H]]
-   val `x-obs-fold-header`: MessageSelector[Request[H]]
-   val `x-dictionary`: DictSelector[Message[H]]
+   val `x-example`: MessageSelector[Request[F, H]]
+   val `x-empty-header`: MessageSelector[Request[F, H]]
+   val `x-ows-header`: MessageSelector[Request[F, H]]
+   val `x-obs-fold-header`: MessageSelector[Request[F, H]]
+   val `x-dictionary`: DictSelector[Message[F, H]]
 
-   given ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+//   given ec: ExecutionContext = scala.concurrent.ExecutionContext.global
    given clock: Clock =
      Clock.fixed(java.time.Instant.ofEpochSecond(16188845000L), java.time.ZoneOffset.UTC).nn
 
@@ -72,7 +73,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
    def `request-target`(value: String): Success[String] = expectedHeader("@request-target", value)
    def expectedHeader(name: String, value: String)      = Success("\"" + name + "\": " + value)
 
-   given specialRequestSelectorOps: run.cosy.http.headers.SelectorOps[Request[H]] =
+   given specialRequestSelectorOps: run.cosy.http.headers.SelectorOps[Request[F, H]] =
      selectorsSecure.requestSelectorOps.append(
        `x-example`,
        `x-empty-header`,
@@ -80,13 +81,13 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `x-obs-fold-header`,
        `x-dictionary`
      )
-   given specialResponseSelectorOps: run.cosy.http.headers.SelectorOps[Response[H]] =
+   given specialResponseSelectorOps: run.cosy.http.headers.SelectorOps[Response[F, H]] =
      selectorsSecure.responseSelectorOps.append(`x-dictionary`)
 
    @throws[Exception]
-   def toRequest(request: HttpMessage): Request[H]
+   def toRequest(request: HttpMessage): Request[F, H]
    @throws[Exception]
-   def toResponse(response: HttpMessage): Response[H]
+   def toResponse(response: HttpMessage): Response[F, H]
 
    // helper method
    extension (bytes: Try[ByteVector])
@@ -112,17 +113,19 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 
    test("§2.1.2 HTTP Field Examples") {
      import messageSignature.signingString
-     val rfcCanonReq: Request[H] = toRequest(`§2.1.2_HeaderField`)
+     val rfcCanonReq: Request[F, H] = toRequest(`§2.1.2_HeaderField`)
      assertEquals(
        `cache-control`.signingString(rfcCanonReq),
        expectedHeader("cache-control", "max-age=60, must-revalidate")
      )
+
      // note: It is Saturday, not Tuesday: either that is an error in the spec, or example of header with wrong date
      //   we fixed it here, because it is difficult to get broken dates past akka
      assertEquals(
        `date`.signingString(rfcCanonReq),
        expectedHeader("date", "Sat, 07 Jun 2014 20:51:35 GMT")
      )
+
      assertEquals(`host`.signingString(rfcCanonReq), expectedHeader("host", "www.example.com"))
      assertEquals(`x-empty-header`.signingString(rfcCanonReq), expectedHeader("x-empty-header", ""))
      assertEquals(
@@ -133,6 +136,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `x-ows-header`.signingString(rfcCanonReq),
        expectedHeader("x-ows-header", "Leading and trailing whitespace.")
      )
+
      assertEquals(
        `x-dictionary`.signingString(rfcCanonReq),
        expectedHeader("x-dictionary", "a=1, b=2;x=1;y=2, c=(a b c)")
@@ -149,7 +153,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
      )(Token("keyid") -> sf"some-key")
      val Some(signatureInput) = SigInput(il): @unchecked
      assertEquals(
-       rfcCanonReq.signingString(signatureInput).toAscii,
+       rfcCanonReq.signingStr(signatureInput).toAscii,
        Success(
          """"cache-control": max-age=60, must-revalidate
 			  |"date": Sat, 07 Jun 2014 20:51:35 GMT
@@ -163,6 +167,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 			  |"x-obs-fold-header" "x-ows-header" "x-dictionary");keyid="some-key"""".rfc8792single
        )
      )
+
      // should fail because there is a header we don't know how to interpret
      val il2 = IList(
        `cache-control`.sf,
@@ -175,12 +180,12 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `x-dictionary`.sf
      )(Token("keyid") -> sf"some-key")
      val Some(signatureInputFail) = SigInput(il2): @unchecked
-     rfcCanonReq.signingString(signatureInputFail) match
+     rfcCanonReq.signingStr(signatureInputFail) match
         case Failure(InvalidSigException(msg)) if msg.contains("x-not-implemented") => assert(true)
         case x => fail("this should have failed because header x-not-implemented is not supported")
 
-        // fail because one of the headers is missing
-     rfcCanonReq.removeHeader("X-Empty-Header").signingString(signatureInput) match
+     // fail because one of the headers is missing
+     rfcCanonReq.removeHeader("X-Empty-Header").signingStr(signatureInput) match
         case Failure(UnableToCreateSigHeaderException(msg)) if msg.contains("x-empty-header") =>
           assert(true)
         case x => fail("not failing in the right way? received:" + x.toString)
@@ -188,15 +193,19 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
         // fail because keyid is not specified (note: this is no longer required in the spec,..., check)
      val ilNoKeyId                   = IList(date.sf, host.sf)()
      val Some(signatureInputNoKeyId) = SigInput(ilNoKeyId): @unchecked
-     assert(rfcCanonReq.signingString(signatureInputNoKeyId).isSuccess)
+
+     assert(rfcCanonReq.signingStr(signatureInputNoKeyId).isSuccess)
+
    }
 
    test("§2.1.3 Dictionary Structured Field Members") {
-     val rfcCanonReq: Request[H] = toRequest(`§2.1.2_HeaderField`)
+
+     val rfcCanonReq: Request[F, H] = toRequest(`§2.1.2_HeaderField`)
      assertEquals(
        `x-dictionary`.signingStringFor(rfcCanonReq),
        expectedHeader("x-dictionary", "a=1, b=2;x=1;y=2, c=(a b c)")
      )
+
      assertEquals(
        `x-dictionary`.signingString(rfcCanonReq),
        expectedHeader("x-dictionary", "a=1, b=2;x=1;y=2, c=(a b c)")
@@ -216,6 +225,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        ),
        expectedKeyedHeader("x-dictionary", "a", "1")
      )
+
      assertEquals(
        `x-dictionary`.signingStringFor(rfcCanonReq, SfString("b")),
        expectedKeyedHeader("x-dictionary", "b", "2;x=1;y=2")
@@ -250,6 +260,8 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 				  |  created=1618884475;expires=1618884775""".rfc8792single
           )
         case None => fail("SigInput is not available")
+
+
    }
 
    val `§2.2.x_Request`: HttpMessage =
@@ -257,7 +269,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        |Host: www.example.com""".stripMargin
 
    test("§2.2.2 Method") {
-     val `req_2.2.2`: Request[H] = toRequest(`§2.1.2_HeaderField`)
+     val `req_2.2.2`: Request[F, H] = toRequest(`§2.1.2_HeaderField`)
      assertEquals(
        `@method`.signingString(`req_2.2.2`),
        expectedHeader("@method", "GET")
@@ -267,6 +279,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `@method`.signingString(`req_2.2.x`),
        expectedHeader("@method", "POST")
      )
+
    }
 
    val `§2.2.3_Request_AbsoluteURI`: HttpMessage =
@@ -295,6 +308,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `@target-uri`.signingString(toRequest(`§2.2.3_Request_AbsoluteURI_2`)),
        expectedHeader(`@target-uri`.lowercaseName, "http://www.example.com/a")
      )
+
    }
 
    test("§2.2.4 Authority") {
@@ -307,6 +321,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `@authority`.signingString(`req_2.2.4`.removeHeader("Host")),
        expectedHeader("@authority", "bblfish.net")
      )
+
    }
 
    test("§2.2.5 Scheme") {
@@ -441,6 +456,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `@query-params`.signingString(`req_2.2.9`, Params(Token("name") -> SfString("param"))),
        expectedNameHeader("@query-params", "param", "value")
      )
+
    }
 
    val `§2.2.10_Response`: HttpMessage =
@@ -452,6 +468,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        `@status`.signingString(toResponse(`§2.2.10_Response`)),
        Success("\"@status\": 200")
      )
+
    }
 
    val `§2.2.11_Request`: HttpMessage =
@@ -492,7 +509,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 		  |{"busy": true, "message": "Your call is very important to us"}""".rfc8792single
 
    test("§2.2.11 Request-Response Signature Binding") {
-     val `req_2.2.11`: Request[H] = toRequest(`§2.2.11_Request`)
+     val `req_2.2.11`: Request[F, H] = toRequest(`§2.2.11_Request`)
      assertEquals(
        `@request-response`.signingString(`req_2.2.11`, Params(Token("key") -> SfString("sig1"))),
        expectedKeyedHeader(
@@ -512,7 +529,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 			  |  ;keyid="test-key-ecc-p256"""".rfc8792single
      ).get
 
-     val `res_2.2.11`: Response[H] = toResponse(`§2.2.11_UnsignedResponse`)
+     val `res_2.2.11`: Response[F, H] = toResponse(`§2.2.11_UnsignedResponse`)
      assertEquals(
        `res_2.2.11`.signingString(siginput, `req_2.2.11`).toAscii,
        Success(
@@ -530,6 +547,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 				  |  ;keyid="test-key-ecc-p256"""".rfc8792single
        )
      )
+
    }
 
    val `§2.3_Request`: HttpMessage =
@@ -579,7 +597,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
      val rfcSigInreq          = toRequest(`§2.3_Request`)
      val Some(sigInHandBuilt) = SigInput(sigInIlist): @unchecked
      val Some(sigin)          = SigInput(siginStr): @unchecked
-     assertEquals(rfcSigInreq.signingString(sigin).toAscii, Success(expectedSigInStr))
+     assertEquals(rfcSigInreq.signingStr(sigin).toAscii, Success(expectedSigInStr))
    }
 
    test("§2.3 Creating the Signature Input String (spec 07)") {
@@ -612,10 +630,11 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        Token("keyid")   -> sf"test-key-rsa-pss"
      )
      assert(SigInput.valid(sigInIlist))
-     val rfcSigInreq: Request[H] = toRequest(`§2.3_Request`)
-     val Some(sigInHandBuilt)    = SigInput(sigInIlist): @unchecked
-     val Some(sigin)             = SigInput(siginStr): @unchecked
-     assertEquals(rfcSigInreq.signingString(sigin).toAscii, Success(expectedSigInStr))
+     val rfcSigInreq: Request[F, H] = toRequest(`§2.3_Request`)
+     val Some(sigInHandBuilt)       = SigInput(sigInIlist): @unchecked
+     val Some(sigin)                = SigInput(siginStr): @unchecked
+     assertEquals(rfcSigInreq.signingStr(sigin).toAscii, Success(expectedSigInStr))
+
    }
 
    val `§3.2_Request`: HttpMessage =
@@ -638,10 +657,13 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 		  |  r5S9IXf2fYJK+eyW4AiGVMvMcOg==:""".rfc8792single
 
    test("§3.2 Verifying a Signature") {
-     val req: Request[H] = toRequest(`§3.2_Request`)
+     val req: Request[F, H] = toRequest(`§3.2_Request`)
+     val auth: HttpSig => IO[KeyIdentified] = req.signatureAuthN(sigSuite.keyidFetcher)
+     val resIO: IO[KeyIdentified] = auth(HttpSig(Rfc8941.Token("sig1")))
      assertIO(
-       req.signatureAuthN(sigSuite.keyidFetcher)(HttpSig(Rfc8941.Token("sig1"))),
-       PureKeyId("test-key-rsa-pss")
+       resIO,
+       PureKeyId("test-key-rsa-pss"),
+       req
      )
    }
 
@@ -694,15 +716,18 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 		  |    j8kSydKoFg6EbVuGbrQijth6I0dDX2/HYcJg==:""".rfc8792single
 
    test("§4.3 Multiple Signatures") {
-     val req: Request[H] = toRequest(`§4.3_Enhanced`)
+     val req: Request[F, H] = toRequest(`§4.3_Enhanced`)
      assertIO(
        req.signatureAuthN(sigSuite.keyidFetcher)(HttpSig(Rfc8941.Token("sig1"))),
-       PureKeyId("test-key-rsa-pss")
+       PureKeyId("test-key-rsa-pss"),
+       req
      ) *>
        assertIO(
          req.signatureAuthN(sigSuite.keyidFetcher)(HttpSig(Rfc8941.Token("proxy_sig"))),
-         PureKeyId("test-key-rsa")
+         PureKeyId("test-key-rsa"),
+         req
        )
+
    }
 
    val B2_test_request: HttpMessage =
@@ -725,13 +750,13 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        |""".stripMargin
 
    test("B.2.1 Minimal Signature Using rsa-pss-sha512") {
-     val req: Request[H] = toRequest(B2_test_request)
+     val req: Request[F, H] = toRequest(B2_test_request)
      val Some(sigInput) = SigInput(
        """();created=1618884475\
 			  |  ;keyid="test-key-rsa-pss";alg="rsa-pss-sha512"""".rfc8792single
      ): @unchecked
      assertEquals(
-       req.signingString(sigInput).toAscii,
+       req.signingStr(sigInput).toAscii,
        Success(
          """"@signature-params": ();created=1618884475\
 			  |  ;keyid="test-key-rsa-pss";alg="rsa-pss-sha512"""".rfc8792single
@@ -767,16 +792,17 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
        reqSignedFromSpec.signatureAuthN(sigSuite.keyidFetcher)(HttpSig(Rfc8941.Token("sig1"))),
        PureKeyId("test-key-rsa-pss")
      )
+
    }
 
    test("B.2.2 Selective Covered Components using rsa-pss-sha512") {
-     val req: Request[H] = toRequest(B2_test_request)
+     val req: Request[F, H] = toRequest(B2_test_request)
      val Some(sigInput) = SigInput(
        """("@authority" "content-type")\
 			  |  ;created=1618884475;keyid="test-key-rsa-pss"""".rfc8792single
      ): @unchecked
      assertEquals(
-       req.signingString(sigInput).toAscii,
+       req.signingStr(sigInput).toAscii,
        Success(
          """"@authority": example.com
 			  |"content-type": application/json
@@ -817,13 +843,13 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
    }
 
    test("B.2.3 Full Coverage using rsa-pss-sha512") {
-     val req: Request[H] = toRequest(B2_test_request)
+     val req: Request[F, H] = toRequest(B2_test_request)
      val siginputStr = """("date" "@method" "@path" "@query" \
 								  |  "@authority" "content-type" "digest" "content-length")\
 								  |  ;created=1618884475;keyid="test-key-rsa-pss"""".rfc8792single
      val Some(sigInput) = SigInput(siginputStr): @unchecked
      assertEquals(
-       req.signingString(sigInput).toAscii,
+       req.signingStr(sigInput).toAscii,
        Success(
          """"date": Tue, 20 Apr 2021 02:07:56 GMT
 			  |"@method": POST
@@ -868,7 +894,7 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
    }
 
    test("B.2.4 Signing a Response using ecdsa-p256-sha256") {
-     val req: Request[H] = toRequest(B2_test_request)
+     val req: Request[F, H] = toRequest(B2_test_request)
      val siginputStr =
        """("content-type" "digest" "content-length")\
          |  ;created=1618884475;keyid="test-key-ecc-p256"""".stripMargin.rfc8792single
@@ -898,9 +924,9 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
      )
    }
 
-   test("Signing a Request using hmac-sha256") {
-     // todo! Symmetric key signature
-   }
+//   test("Signing a Request using hmac-sha256"). {
+//     // todo! Symmetric key signature
+//   }
 
    val B3_Request: HttpMessage =
      """POST /foo?Param=value&pet=Dog HTTP/1.1
@@ -929,11 +955,11 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 		  |{"hello": "world"}""".rfc8792single
 
    test("B.3. TLS-Terminating Proxy") {
-     val req: Request[H] = toRequest(B3_ProxyEnhanced_Request)
+     val req: Request[F, H] = toRequest(B3_ProxyEnhanced_Request)
      val siginputStr = """("@path" "@query" "@method" "@authority" \
 								  |  "client-cert");created=1618884475;keyid="test-key-ecc-p256"""".rfc8792single
      val Some(sigInput) = SigInput(siginputStr): @unchecked
-     val sigStr         = req.signingString(sigInput)
+     val sigStr         = req.signingStr(sigInput)
 //  the current 07 spec wrongly has it that the @query line does not start with `?`
 //  see https://github.com/httpwg/http-extensions/issues/1901#issuecomment-1024075718
 //		assertEquals(sigStr.toAscii,
@@ -985,9 +1011,9 @@ trait HttpMessageSigningSuite[H <: Http] extends CatsEffectSuite:
 end HttpMessageSigningSuite
 
 class SigningSuiteHelpers(using pemutils: bobcats.util.PEMUtils):
-   import run.cosy.http.auth.MessageSignature as MS
    import bobcats.SigningHttpMessages.`test-key-rsa-pss`
    import bobcats.util.PEMUtils.PKCS8_PEM
+   import run.cosy.http.auth.MessageSignature as MS
    def verifierFor(
        spec: Try[SPKIKeySpec[AsymmetricKeyAlg]],
        sig: Signature,

--- a/ietfSigTests/shared/src/main/scala/run/cosy/http/auth/HttpMessageSigningSuite.scala
+++ b/ietfSigTests/shared/src/main/scala/run/cosy/http/auth/HttpMessageSigningSuite.scala
@@ -22,7 +22,7 @@ import cats.effect.Async
 import _root_.run.cosy.http.{Http, HttpOps}
 //todo: SignatureBytes is less likely to class with objects like Signature
 import bobcats.Verifier.{SigningString, Signature as SignatureBytes}
-import bobcats.{AsymmetricKeyAlg, SPKIKeySpec, SigningHttpMessages}
+import bobcats.{AsymmetricKeyAlg, SPKIKeySpec, HttpMessageSignaturesV07 }
 import _root_.run.cosy.http.headers.*
 import _root_.run.cosy.http.headers.Rfc8941.*
 import _root_.run.cosy.http.headers.Rfc8941.SyntaxHelper.*
@@ -1013,7 +1013,7 @@ trait HttpMessageSigningSuite[F[_], H <: Http] extends CatsEffectSuite:
 end HttpMessageSigningSuite
 
 class SigningSuiteHelpers(using pemutils: bobcats.util.PEMUtils):
-   import bobcats.SigningHttpMessages.`test-key-rsa-pss`
+   import bobcats.HttpMessageSignaturesV07.`test-key-rsa-pss`
    import bobcats.util.PEMUtils.PKCS8_PEM
    import run.cosy.http.auth.MessageSignature as MS
    def verifierFor(
@@ -1036,19 +1036,19 @@ class SigningSuiteHelpers(using pemutils: bobcats.util.PEMUtils):
      pemutils.getPrivateKeySpec(keyinfo.privatePk8Key, keyinfo.keyAlg)
 
    lazy val rsaPSSPubKey: Try[SPKIKeySpec[AsymmetricKeyAlg]] =
-     publicKeySpec(bobcats.SigningHttpMessages.`test-key-rsa-pss`)
+     publicKeySpec(bobcats.HttpMessageSignaturesV07.`test-key-rsa-pss`)
 
    lazy val rsaPubKey: Try[SPKIKeySpec[AsymmetricKeyAlg]] =
-     publicKeySpec(bobcats.SigningHttpMessages.`test-key-rsa`)
+     publicKeySpec(bobcats.HttpMessageSignaturesV07.`test-key-rsa`)
 
    lazy val rsaPSSPrivKey: Try[PKCS8KeySpec[AsymmetricKeyAlg]] =
-     privateKeySpec(bobcats.SigningHttpMessages.`test-key-rsa-pss`)
+     privateKeySpec(bobcats.HttpMessageSignaturesV07.`test-key-rsa-pss`)
 
    lazy val ecc_256_PubKey: Try[SPKIKeySpec[AsymmetricKeyAlg]] =
-     publicKeySpec(bobcats.SigningHttpMessages.`test-key-ecc-p256`)
+     publicKeySpec(bobcats.HttpMessageSignaturesV07.`test-key-ecc-p256`)
 
    lazy val ecc_256_PrivKey: Try[PKCS8KeySpec[AsymmetricKeyAlg]] =
-     privateKeySpec(bobcats.SigningHttpMessages.`test-key-ecc-p256`)
+     privateKeySpec(bobcats.HttpMessageSignaturesV07.`test-key-ecc-p256`)
 
    lazy val rsaPSSSigner: IO[ByteVector => IO[ByteVector]] =
      for

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Dependencies {
   object tests {
     //	val utest = Def.setting("com.lihaoyi" %%% "utest" % "0.7.10")
     // https://github.com/scalameta/munit
-    lazy val munit = Def.setting("org.scalameta" %%% "munit" % "0.7.29")
+    lazy val munit = Def.setting("org.scalameta" %%% "munit" % "1.0.0-M6")
     // https://github.com/typelevel/munit-cats-effect
-    lazy val munitEffect = Def.setting("org.typelevel" %%% "munit-cats-effect-3" % "1.0.7")
+    lazy val munitEffect = Def.setting("org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3")
 
     lazy val discipline = Def.setting("org.typelevel" %%% "discipline-munit" % "1.0.9")
     lazy val laws       = Def.setting("org.typelevel" %%% "cats-laws" % "2.7.0")
@@ -20,9 +20,11 @@ object Dependencies {
   // needed for modelJS
   lazy val sonatypeSNAPSHOT: MavenRepository =
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+    
   object Ver {
-    val scala = "3.1.1"
+    val scala = "3.1.3"
   }
+  
   // https://http4s.org/v1.0/client/
   object http4s {
     val Ver = "1.0.0-M37"
@@ -46,7 +48,12 @@ object Dependencies {
     // https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/crypto/bobcats_3/
     lazy val bobcats =
       Def.setting("net.bblfish.crypto" %%% "bobcats" % "0.2-69106e6-SNAPSHOT")
+      
+    // https://index.scala-lang.org/typelevel/cats-effect/artifacts/cats-effect/3.3.14
+    // todo: other libraries deped on cats effect, is this the right version?
+    lazy val catsEffect = Def.setting("org.typelevel" %% "cats-effect" % "3.3.14")
   }
+  
   object akka {
     lazy val typed       = akka("akka-actor-typed", CoreVersion)
     lazy val stream      = akka("akka-stream", CoreVersion)
@@ -56,6 +63,7 @@ object Dependencies {
     def apply(id: String, version: String): Def.Initialize[ModuleID] =
       Def.setting("com.typesafe.akka" %% id % version cross CrossVersion.for3Use2_13)
   }
+  
   object java {
 
     /** Apache 2 License

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   }
   // https://http4s.org/v1.0/client/
   object http4s {
-    val Ver = "1.0.0-M31"
+    val Ver = "1.0.0-M37"
 
     lazy val core   = http4s("http4s-core")
     lazy val client = http4s("http4s-client")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
       Def.setting("net.bblfish.crypto" %%% "bobcats" % "0.2-7a91946-SNAPSHOT")
 
     // https://index.scala-lang.org/typelevel/cats-effect/artifacts/cats-effect/3.3.14
-    // todo: other libraries deped on cats effect, is this the right version?
+    // todo: other libraries depend on cats effect, is this the right version?
     lazy val catsEffect = Def.setting("org.typelevel" %% "cats-effect" % "3.3.14")
   }
 
@@ -71,7 +71,7 @@ object Dependencies {
       * @see
       *   https://connect2id.com/products/nimbus-jose-jwt/examples/jwk-conversion
       */
-    lazy val nimbusDS = "com.nimbusds" % "nimbus-jose-jwt" % "9.25.4"
+    lazy val nimbusDS = "com.nimbusds" % "nimbus-jose-jwt" % "9.25.6"
 
     /** BouncyCastle (for parsing PEM encoded objects at present in test) MIT style License
       *

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Dependencies {
   object tests {
     //	val utest = Def.setting("com.lihaoyi" %%% "utest" % "0.7.10")
     // https://github.com/scalameta/munit
-    lazy val munit = Def.setting("org.scalameta" %%% "munit" % "1.0.0-M6")
+    lazy val munit = Def.setting("org.scalameta" %%% "munit" % "0.7.29")
     // https://github.com/typelevel/munit-cats-effect
-    lazy val munitEffect = Def.setting("org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3")
+    lazy val munitEffect = Def.setting("org.typelevel" %%% "munit-cats-effect-3" % "1.0.7")
 
     lazy val discipline = Def.setting("org.typelevel" %%% "discipline-munit" % "1.0.9")
     lazy val laws       = Def.setting("org.typelevel" %%% "cats-laws" % "2.7.0")
@@ -20,11 +20,11 @@ object Dependencies {
   // needed for modelJS
   lazy val sonatypeSNAPSHOT: MavenRepository =
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-    
+
   object Ver {
     val scala = "3.1.3"
   }
-  
+
   // https://http4s.org/v1.0/client/
   object http4s {
     val Ver = "1.0.0-M37"
@@ -36,7 +36,7 @@ object Dependencies {
 
     // https://search.maven.org/artifact/org.http4s/http4s-dom_sjs1_3/1.0.0-M30/jar
     // https://github.com/http4s/http4s-dom
-    lazy val Dom = http4s("http4s-dom")
+//    lazy val Dom = Def.setting("org.http4s" %%% "http4s-dom" % "0.2.3")
     def apply(packg: String): Def.Initialize[sbt.ModuleID] =
       Def.setting("org.http4s" %%% packg % Ver)
   }
@@ -44,26 +44,26 @@ object Dependencies {
   object cats {
     // https://search.maven.org/artifact/org.typelevel/cats-parse_3/0.3.6/jar
     // https://search.maven.org/artifact/org.typelevel/cats-parse_3
-    lazy val parse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3-25-7b524da")
+    lazy val parse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3.8")
     // https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/crypto/bobcats_3/
     lazy val bobcats =
-      Def.setting("net.bblfish.crypto" %%% "bobcats" % "0.2-69106e6-SNAPSHOT")
-      
+      Def.setting("net.bblfish.crypto" %%% "bobcats" % "0.2-7a91946-SNAPSHOT")
+
     // https://index.scala-lang.org/typelevel/cats-effect/artifacts/cats-effect/3.3.14
     // todo: other libraries deped on cats effect, is this the right version?
     lazy val catsEffect = Def.setting("org.typelevel" %% "cats-effect" % "3.3.14")
   }
-  
+
   object akka {
     lazy val typed       = akka("akka-actor-typed", CoreVersion)
     lazy val stream      = akka("akka-stream", CoreVersion)
     lazy val http        = akka("akka-http", HttpVersion)
-    lazy val CoreVersion = "2.6.18"
-    lazy val HttpVersion = "10.2.8"
+    lazy val CoreVersion = "2.6.20"
+    lazy val HttpVersion = "10.2.10"
     def apply(id: String, version: String): Def.Initialize[ModuleID] =
       Def.setting("com.typesafe.akka" %% id % version cross CrossVersion.for3Use2_13)
   }
-  
+
   object java {
 
     /** Apache 2 License
@@ -71,7 +71,7 @@ object Dependencies {
       * @see
       *   https://connect2id.com/products/nimbus-jose-jwt/examples/jwk-conversion
       */
-    lazy val nimbusDS = "com.nimbusds" % "nimbus-jose-jwt" % "9.15.2"
+    lazy val nimbusDS = "com.nimbusds" % "nimbus-jose-jwt" % "9.25.4"
 
     /** BouncyCastle (for parsing PEM encoded objects at present in test) MIT style License
       *
@@ -83,7 +83,7 @@ object Dependencies {
     lazy val bouncy = Seq(
       // "org.bouncycastle" % "bcprov-jdk15to18" % bouncyVersion,
       // "org.bouncycastle" % "bctls-jdk15to18" % bouncyVersion,
-      "org.bouncycastle" % "bcpkix-jdk15to18" % "1.69" % Test
+      "org.bouncycastle" % "bcpkix-jdk15to18" % "1.72" % Test
     )
   }
   object NPM {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
     lazy val parse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3.8")
     // https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/crypto/bobcats_3/
     lazy val bobcats =
-      Def.setting("net.bblfish.crypto" %%% "bobcats" % "0.2-7a91946-SNAPSHOT")
+      Def.setting("net.bblfish.crypto" %%% "bobcats" % "0.2-2b3834e-SNAPSHOT")
 
     // https://index.scala-lang.org/typelevel/cats-effect/artifacts/cats-effect/3.3.14
     // todo: other libraries depend on cats effect, is this the right version?

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 //selenium testing
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.1.1"
 
-resolvers += Resolver.sonatypeRepo("snapshots")
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 // https://typelevel.org/sbt-typelevel/index.html
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.5")
-addSbtPlugin("org.scala-js"  % "sbt-scalajs"   % "1.9.0")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.5.0-M5")
+addSbtPlugin("org.scala-js"  % "sbt-scalajs"   % "1.11.0")
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
Http4s Messages have a body that depends on F[_]. Loosing this
info lost type info when creating new http headers. (Akka does
not have this problem...)
- update to http4s M37
- update libs + track F[_] body for http4s
